### PR TITLE
Fix schedule output duplication

### DIFF
--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -27,11 +27,13 @@ def getTeamsVariablesForAllWeeks(variables, team1, team2, weeks_param, teams_par
 def _get_schedule_data(variables, weeks_param, teams_param):
     schedule_data = []
     schedule_data.append(['Week', 'Team1', 'Team2'])
-    for w in weeks_param: 
+    for w in weeks_param:
         for i in teams_param:
             for j in teams_param:
-                  if (variables[i][j][w].solution_value() > 0) :
-                      schedule_data.append([w, i, j]) 
+                # each matchup is represented twice in the solver (i vs j and
+                # j vs i).  Only record one of them in the schedule output.
+                if (i < j) and (variables[i][j][w].solution_value() > 0):
+                    schedule_data.append([w, i, j])
     return schedule_data
 
 def generate_schedule_csv(num_weeks, num_teams):

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -49,6 +49,20 @@ class TestScheduleGenerator(unittest.TestCase):
         result_invalid_teams = schedule_generator.getTeamsVariablesForAllWeeks(self.mock_variables, 99, 100, self.weeks, self.teams)
         self.assertEqual(result_invalid_teams, [])
 
+    def test_get_schedule_data_no_duplicate_matchups(self):
+        weeks_param = range(1)
+        teams_param = range(2)
+        variables = [[[Mock() for _ in weeks_param] for _ in teams_param] for _ in teams_param]
+        variables[0][1][0].solution_value.return_value = 1
+        variables[1][0][0].solution_value.return_value = 1
+        variables[0][0][0].solution_value.return_value = 0
+        variables[1][1][0].solution_value.return_value = 0
+
+        schedule_data = schedule_generator._get_schedule_data(variables, weeks_param, teams_param)
+
+        expected = [['Week', 'Team1', 'Team2'], [0, 0, 1]]
+        self.assertEqual(schedule_data, expected)
+
     @patch('src.schedule_generator.pywraplp.Solver')
     def test_generate_schedule_csv_optimal_solution(self, MockSolver):
         mock_solver_instance = Mock()


### PR DESCRIPTION
## Summary
- ensure `_get_schedule_data` only records a single row per matchup

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'ortools')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement ortools)*

------
https://chatgpt.com/codex/tasks/task_e_685dcd2d8984832e9d8da2a7c0bdb66e