### PR TITLE
Fix comment typo

### DIFF
--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -65,7 +65,7 @@ def generate_schedule_csv(num_weeks, num_teams):
 
     # each team plays 1 game per week
     #   for each week and each team
-    #      sum of all variables inlucding that team for that week = 2
+    #      sum of all variables including that team for that week = 2
     for week in weeks:
         for team in teams:
             constraint = solver.RowConstraint(2, 2, "")


### PR DESCRIPTION
## Summary
- fix spelling of "including" in schedule_generator comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd07af194832e9e66eb8c9654e27d