### PR TITLE
Split integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install build run clean test
+.PHONY: install build run clean test test-unit test-integration
 
 install:
 	pip install -r requirements.txt
@@ -12,5 +12,10 @@ run: build
 clean:
 	rm -f src/scheduler_pb2.py src/scheduler_pb2_grpc.py
 
-test:
+test: test-unit test-integration
+
+test-unit:
 	PYTHONPATH=src python3 -m unittest tests/test_schedule_generator.py
+
+test-integration:
+	PYTHONPATH=src python3 -m unittest tests/test_integration_schedule_generator.py

--- a/tests/test_integration_schedule_generator.py
+++ b/tests/test_integration_schedule_generator.py
@@ -1,5 +1,5 @@
 import unittest
-from src import schedule_generator
+import schedule_generator
 
 class TestScheduleGeneratorIntegration(unittest.TestCase):
     def test_generate_schedule_csv_real_solver(self):

--- a/tests/test_integration_schedule_generator.py
+++ b/tests/test_integration_schedule_generator.py
@@ -1,0 +1,21 @@
+import unittest
+from src import schedule_generator
+
+class TestScheduleGeneratorIntegration(unittest.TestCase):
+    def test_generate_schedule_csv_real_solver(self):
+        """Integration test using the real solver"""
+        num_weeks = 13
+        num_teams = 10
+
+        csv_output = schedule_generator.generate_schedule_csv(num_weeks, num_teams)
+
+        self.assertNotEqual(csv_output, "The problem does not have an optimal solution.")
+        self.assertNotEqual(csv_output, "Error: Solver could not be created.")
+
+        lines = csv_output.strip().splitlines()
+        self.assertEqual(lines[0], "Week,Team1,Team2")
+        expected_lines = 1 + num_weeks * num_teams // 2
+        self.assertEqual(len(lines), expected_lines)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -134,20 +134,5 @@ class TestScheduleGenerator(unittest.TestCase):
         result = schedule_generator.generate_schedule_csv(2, 2)
         self.assertEqual(result, "Error: Solver could not be created.")
 
-    def test_generate_schedule_csv_real_solver(self):
-        """Integration test using the real solver"""
-        num_weeks = 13
-        num_teams = 10
-
-        csv_output = schedule_generator.generate_schedule_csv(num_weeks, num_teams)
-
-        self.assertNotEqual(csv_output, "The problem does not have an optimal solution.")
-        self.assertNotEqual(csv_output, "Error: Solver could not be created.")
-
-        lines = csv_output.strip().splitlines()
-        self.assertEqual(lines[0], "Week,Team1,Team2")
-        expected_lines = 1 + num_weeks * num_teams // 2
-        self.assertEqual(len(lines), expected_lines)
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- split integration tests from unit tests

## Testing
- `PYTHONPATH=src python3 -m unittest tests/test_schedule_generator.py`
- `PYTHONPATH=src python3 -m unittest tests/test_integration_schedule_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_685eb3835550832e96e8621a03ca2873