### PR TITLE
Add make target for server integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,6 @@ test-unit:
 	PYTHONPATH=src python3 -m unittest tests/test_schedule_generator.py
 
 test-integration:
-	PYTHONPATH=src python3 -m unittest tests/test_integration_schedule_generator.py
+	PYTHONPATH=src python3 -m unittest \
+	tests/test_integration_schedule_generator.py \
+	tests/test_integration_server.py

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import time
+import unittest
+import subprocess
+from multiprocessing import Process
+
+import grpc
+
+# Compile protobuf definitions before importing the server
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+subprocess.check_call([
+    sys.executable,
+    '-m', 'grpc_tools.protoc',
+    '-Isrc/protos',
+    '--python_out=src',
+    '--grpc_python_out=src',
+    'src/protos/scheduler.proto'
+], cwd=ROOT_DIR)
+
+import scheduler_pb2
+import scheduler_pb2_grpc
+import server
+
+
+def _run_server():
+    server.serve()
+
+
+class TestServerIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.proc = Process(target=_run_server)
+        cls.proc.start()
+        # give the server some time to start
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_generate_schedule_default_response(self):
+        channel = grpc.insecure_channel('localhost:50051')
+        stub = scheduler_pb2_grpc.SchedulerStub(channel)
+        response = stub.GenerateSchedule(scheduler_pb2.ScheduleRequest())
+        self.assertIsInstance(response, scheduler_pb2.ScheduleResponse)
+        self.assertEqual(len(response.matchups), 0)
+        channel.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- run the new gRPC server integration test from `make test-integration`

## Testing
- `make test-unit`
- `make test-integration`
- `PYTHONPATH=src python3 -m unittest tests/test_integration_server.py`


------
https://chatgpt.com/codex/tasks/task_e_685ebd9a4594832ea3ef8f9eeba02e6e