### PR TITLE
Add example request script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,34 @@ make run
 ```
 
 The server will start on port `50051`.
+
+## Example Request
+
+After starting the server, you can send a gRPC request to it using Python. The snippet below builds a `ScheduleRequest` with ten teams and prints the generated schedule.
+
+```python
+import grpc
+import scheduler_pb2
+import scheduler_pb2_grpc
+
+channel = grpc.insecure_channel('localhost:50051')
+stub = scheduler_pb2_grpc.SchedulerStub(channel)
+
+request = scheduler_pb2.ScheduleRequest()
+for i in range(10):
+    team = scheduler_pb2.Team(name=f'Team {i+1}', division_id=0)
+    request.league.append(team)
+
+response = stub.GenerateSchedule(request)
+print(response)
+```
+
+Ensure the protobuf files are built (`make build`) so that `scheduler_pb2` and `scheduler_pb2_grpc` are available before running the snippet.
+
+You can also run the example script in `examples/example_request.py` to see the
+same request in action:
+
+```bash
+make build
+python examples/example_request.py
+```

--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+# Ensure the generated gRPC modules are on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import grpc
+import scheduler_pb2
+import scheduler_pb2_grpc
+
+
+def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
+    request = scheduler_pb2.ScheduleRequest()
+    for i in range(num_teams):
+        team = scheduler_pb2.Team(name=f"Team {i+1}", division_id=0)
+        request.league.append(team)
+    return request
+
+
+def main() -> None:
+    channel = grpc.insecure_channel("localhost:50051")
+    stub = scheduler_pb2_grpc.SchedulerStub(channel)
+
+    request = build_request(10)
+    response = stub.GenerateSchedule(request)
+
+    for week_idx, weekly in enumerate(response.matchups, start=1):
+        print(f"Week {week_idx}")
+        for matchup in weekly.matchups:
+            print(f"  {matchup.team1.name} vs {matchup.team2.name}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `examples/example_request.py` for a simple gRPC client
- document example script in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685ee839459c832eab68ae2325d5e940