### PR TITLE
Split unit and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Install dependencies
         run: make install
 
-      - name: Run tests
-        run: make test
+      - name: Run unit tests
+        run: make test-unit
+
+      - name: Run integration tests
+        run: make test-integration
 
       - name: Build server
         run: make build


### PR DESCRIPTION
## Summary
- split unit and integration tests into distinct steps in CI

## Testing
- `make test-unit`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_685ef9e06b88832eb115b5b388f70610