### PR TITLE
Improve logging for integration tests

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1,18 +1,28 @@
 from concurrent import futures
+import logging
 import grpc
 from grpc_reflection.v1alpha import reflection
 
 import src.scheduler_pb2 as scheduler_pb2
 import src.scheduler_pb2_grpc as scheduler_pb2_grpc
 
+
+logger = logging.getLogger(__name__)
+
 class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
     def GenerateSchedule(self, request, context):
-        # Implement your scheduling logic herecan
+        logger.info("GenerateSchedule request received with %d teams", len(request.league))
         response = scheduler_pb2.ScheduleResponse()
         # Your logic to populate response
+        logger.info("Returning schedule response with %d matchups", len(response.matchups))
         return response
 
 def serve():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+    )
+
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     scheduler_pb2_grpc.add_SchedulerServicer_to_server(SchedulerServicer(), server)
 
@@ -25,7 +35,7 @@ def serve():
 
     server.add_insecure_port('[::]:50051')
     server.start()
-    print("Server started on port 50051 with reflection enabled")
+    logger.info("Server started on port 50051 with reflection enabled")
     server.wait_for_termination()
 
 if __name__ == '__main__':

--- a/tests/test_integration_schedule_generator.py
+++ b/tests/test_integration_schedule_generator.py
@@ -1,4 +1,5 @@
 import unittest
+import logging
 import schedule_generator
 
 class TestScheduleGeneratorIntegration(unittest.TestCase):
@@ -7,7 +8,15 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
         num_weeks = 13
         num_teams = 10
 
+        logging.basicConfig(
+            level=logging.INFO,
+            format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+        )
+        logging.info("Calling generate_schedule_csv with %d weeks and %d teams", num_weeks, num_teams)
+
         csv_output = schedule_generator.generate_schedule_csv(num_weeks, num_teams)
+
+        logging.info("generate_schedule_csv returned %d characters of CSV", len(csv_output))
 
         self.assertNotEqual(csv_output, "The problem does not have an optimal solution.")
         self.assertNotEqual(csv_output, "Error: Solver could not be created.")
@@ -18,4 +27,8 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
         self.assertEqual(len(lines), expected_lines)
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+    )
     unittest.main()

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -4,6 +4,7 @@ import time
 import unittest
 import subprocess
 from multiprocessing import Process
+import logging
 
 import grpc
 
@@ -24,30 +25,49 @@ import server
 
 
 def _run_server():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+    )
+    logging.info("Starting server in subprocess for integration test")
     server.serve()
 
 
 class TestServerIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        logging.basicConfig(
+            level=logging.INFO,
+            format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+        )
+        logging.info("Launching gRPC server process for integration test")
         cls.proc = Process(target=_run_server)
         cls.proc.start()
         # give the server some time to start
         time.sleep(1)
+        logging.info("Server process started")
 
     @classmethod
     def tearDownClass(cls):
+        logging.info("Terminating gRPC server process")
         cls.proc.terminate()
         cls.proc.join()
+        logging.info("Server process terminated")
 
     def test_generate_schedule_default_response(self):
+        logging.info("Sending GenerateSchedule request to server")
         channel = grpc.insecure_channel('localhost:50051')
         stub = scheduler_pb2_grpc.SchedulerStub(channel)
         response = stub.GenerateSchedule(scheduler_pb2.ScheduleRequest())
+        logging.info("Received response with %d matchups", len(response.matchups))
         self.assertIsInstance(response, scheduler_pb2.ScheduleResponse)
         self.assertEqual(len(response.matchups), 0)
         channel.close()
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+    )
     unittest.main()


### PR DESCRIPTION
## Summary
- add logging setup to gRPC server and emit startup/request messages
- add detailed logging to server integration tests
- add logging to schedule generator integration test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685efad9df2c832ea1b6ddf159d457be