### PR TITLE
Implement server schedule generation

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1,20 +1,54 @@
 from concurrent import futures
 import logging
+import csv
+import io
+
 import grpc
 from grpc_reflection.v1alpha import reflection
 
 import src.scheduler_pb2 as scheduler_pb2
 import src.scheduler_pb2_grpc as scheduler_pb2_grpc
+from src import schedule_generator
 
 
 logger = logging.getLogger(__name__)
 
 class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
     def GenerateSchedule(self, request, context):
-        logger.info("GenerateSchedule request received with %d teams", len(request.league))
-        response = scheduler_pb2.ScheduleResponse()
-        # Your logic to populate response
-        logger.info("Returning schedule response with %d matchups", len(response.matchups))
+        logger.info(
+            "GenerateSchedule request received with %d teams", len(request.league)
+        )
+
+        num_teams = len(request.league)
+        if num_teams == 0:
+            logger.info("No teams provided, returning empty schedule")
+            return scheduler_pb2.ScheduleResponse()
+
+        # Generate the schedule CSV using the existing generator
+        csv_output = schedule_generator.generate_schedule_csv(13, num_teams)
+
+        # Parse the CSV into the gRPC response
+        weeks: list[scheduler_pb2.WeeklyMatchups] = []
+        reader = csv.reader(io.StringIO(csv_output))
+        next(reader, None)  # skip header
+        for row in reader:
+            week_idx = int(row[0])
+            team1_idx = int(row[1])
+            team2_idx = int(row[2])
+
+            while len(weeks) <= week_idx:
+                weeks.append(scheduler_pb2.WeeklyMatchups())
+
+            matchup = scheduler_pb2.Matchup(
+                team1=request.league[team1_idx],
+                team2=request.league[team2_idx],
+            )
+            weeks[week_idx].matchups.append(matchup)
+
+        response = scheduler_pb2.ScheduleResponse(matchups=weeks)
+        logger.info(
+            "Returning schedule response with %d weeks", len(response.matchups)
+        )
         return response
 
 def serve():

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -54,14 +54,27 @@ class TestServerIntegration(unittest.TestCase):
         cls.proc.join()
         logging.info("Server process terminated")
 
-    def test_generate_schedule_default_response(self):
+    def test_generate_schedule_generates_matchups(self):
         logging.info("Sending GenerateSchedule request to server")
-        channel = grpc.insecure_channel('localhost:50051')
+        channel = grpc.insecure_channel("localhost:50051")
         stub = scheduler_pb2_grpc.SchedulerStub(channel)
-        response = stub.GenerateSchedule(scheduler_pb2.ScheduleRequest())
-        logging.info("Received response with %d matchups", len(response.matchups))
+
+        request = scheduler_pb2.ScheduleRequest()
+        for i in range(10):
+            request.league.append(
+                scheduler_pb2.Team(name=f"Team {i}", division_id=0)
+            )
+
+        response = stub.GenerateSchedule(request)
+        logging.info(
+            "Received response with %d weeks", len(response.matchups)
+        )
+
         self.assertIsInstance(response, scheduler_pb2.ScheduleResponse)
-        self.assertEqual(len(response.matchups), 0)
+        self.assertEqual(len(response.matchups), 13)
+        for weekly in response.matchups:
+            self.assertEqual(len(weekly.matchups), 5)
+
         channel.close()
 
 


### PR DESCRIPTION
## Summary
- hook up gRPC server to call schedule generator
- parse generated schedule into response messages
- extend integration server test for new behavior

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685f016dafa0832e9cc76db86896709e