### PR TITLE
Remove CSV generation from schedule generator

### DIFF
--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -1,5 +1,3 @@
-import io
-import csv
 from ortools.linear_solver import pywraplp
 
 # Returns all of the variables in variables that correspond to the given team playing in a game in the given week
@@ -36,7 +34,7 @@ def _get_schedule_data(variables, weeks_param, teams_param):
                     schedule_data.append([w, i, j])
     return schedule_data
 
-def generate_schedule_csv(num_weeks, num_teams):
+def generate_schedule(num_weeks, num_teams):
     weeks = range(num_weeks)
     teams = range(num_teams)
 
@@ -127,11 +125,7 @@ def generate_schedule_csv(num_weeks, num_teams):
 
     if status == pywraplp.Solver.OPTIMAL:
         schedule_data = _get_schedule_data(variables, weeks, teams)
-        output = io.StringIO()
-        writer = csv.writer(output)
-        for row in schedule_data:
-            writer.writerow(row)
-        return output.getvalue()
+        return schedule_data
     else:
         return "The problem does not have an optimal solution."
 
@@ -139,8 +133,8 @@ def main():
     # Default values for weeks and teams
     default_weeks = 13
     default_teams = 10
-    csv_output = generate_schedule_csv(default_weeks, default_teams)
-    print(csv_output)
+    schedule_data = generate_schedule(default_weeks, default_teams)
+    print(schedule_data)
 
 if __name__ == "__main__":
     main()

--- a/src/server.py
+++ b/src/server.py
@@ -1,7 +1,5 @@
 from concurrent import futures
 import logging
-import csv
-import io
 import grpc
 from grpc_reflection.v1alpha import reflection
 
@@ -25,17 +23,14 @@ class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
             logger.info("No teams provided in request")
             return response
 
-        csv_output = schedule_generator.generate_schedule_csv(13, num_teams)
+        schedule_data = schedule_generator.generate_schedule(13, num_teams)
 
-        if csv_output.startswith("Error") or csv_output.startswith("The problem"):
-            logger.error("Schedule generation failed: %s", csv_output)
+        if isinstance(schedule_data, str):
+            logger.error("Schedule generation failed: %s", schedule_data)
             return response
 
-        reader = csv.reader(io.StringIO(csv_output))
-        header = next(reader, None)
-
         schedule = {}
-        for week_str, team1_idx, team2_idx in reader:
+        for week_str, team1_idx, team2_idx in schedule_data[1:]:
             week = int(week_str)
             schedule.setdefault(week, []).append((int(team1_idx), int(team2_idx)))
 

--- a/tests/test_integration_schedule_generator.py
+++ b/tests/test_integration_schedule_generator.py
@@ -3,7 +3,7 @@ import logging
 import schedule_generator
 
 class TestScheduleGeneratorIntegration(unittest.TestCase):
-    def test_generate_schedule_csv_real_solver(self):
+    def test_generate_schedule_real_solver(self):
         """Integration test using the real solver"""
         num_weeks = 13
         num_teams = 10
@@ -12,19 +12,18 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
             level=logging.INFO,
             format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
         )
-        logging.info("Calling generate_schedule_csv with %d weeks and %d teams", num_weeks, num_teams)
+        logging.info("Calling generate_schedule with %d weeks and %d teams", num_weeks, num_teams)
 
-        csv_output = schedule_generator.generate_schedule_csv(num_weeks, num_teams)
+        schedule_data = schedule_generator.generate_schedule(num_weeks, num_teams)
 
-        logging.info("generate_schedule_csv returned %d characters of CSV", len(csv_output))
+        logging.info("generate_schedule returned %d rows", len(schedule_data))
 
-        self.assertNotEqual(csv_output, "The problem does not have an optimal solution.")
-        self.assertNotEqual(csv_output, "Error: Solver could not be created.")
+        self.assertNotEqual(schedule_data, "The problem does not have an optimal solution.")
+        self.assertNotEqual(schedule_data, "Error: Solver could not be created.")
 
-        lines = csv_output.strip().splitlines()
-        self.assertEqual(lines[0], "Week,Team1,Team2")
-        expected_lines = 1 + num_weeks * num_teams // 2
-        self.assertEqual(len(lines), expected_lines)
+        self.assertEqual(schedule_data[0], ["Week", "Team1", "Team2"])
+        expected_rows = 1 + num_weeks * num_teams // 2
+        self.assertEqual(len(schedule_data), expected_rows)
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -1,8 +1,6 @@
 import unittest
 from unittest.mock import Mock, patch
 from src import schedule_generator
-import csv
-import io
 
 class TestScheduleGenerator(unittest.TestCase):
 
@@ -87,7 +85,7 @@ class TestScheduleGenerator(unittest.TestCase):
         self.assertEqual(schedule_data, expected)
 
     @patch('src.schedule_generator.pywraplp.Solver')
-    def test_generate_schedule_csv_optimal_solution(self, MockSolver):
+    def test_generate_schedule_optimal_solution(self, MockSolver):
         mock_solver_instance = Mock()
         MockSolver.CreateSolver.return_value = mock_solver_instance
 
@@ -111,27 +109,33 @@ class TestScheduleGenerator(unittest.TestCase):
                 [1, 0, 1],
                 [1, 1, 0]
             ]
-            result_csv = schedule_generator.generate_schedule_csv(2, 2) # 2 weeks, 2 teams
+            result = schedule_generator.generate_schedule(2, 2)
 
-        expected_csv = "Week,Team1,Team2\r\n0,0,1\r\n0,1,0\r\n1,0,1\r\n1,1,0\r\n"
-        self.assertEqual(result_csv, expected_csv)
+        expected = [
+            ['Week', 'Team1', 'Team2'],
+            [0, 0, 1],
+            [0, 1, 0],
+            [1, 0, 1],
+            [1, 1, 0]
+        ]
+        self.assertEqual(result, expected)
 
     @patch('src.schedule_generator.pywraplp.Solver')
-    def test_generate_schedule_csv_no_optimal_solution(self, MockSolver):
+    def test_generate_schedule_no_optimal_solution(self, MockSolver):
         mock_solver_instance = Mock()
         MockSolver.CreateSolver.return_value = mock_solver_instance
 
         # Mock solver behavior for no optimal solution
         mock_solver_instance.Solve.return_value = schedule_generator.pywraplp.Solver.INFEASIBLE
 
-        result = schedule_generator.generate_schedule_csv(2, 2)
+        result = schedule_generator.generate_schedule(2, 2)
         self.assertEqual(result, "The problem does not have an optimal solution.")
 
     @patch('src.schedule_generator.pywraplp.Solver')
-    def test_generate_schedule_csv_solver_creation_failure(self, MockSolver):
+    def test_generate_schedule_solver_creation_failure(self, MockSolver):
         MockSolver.CreateSolver.return_value = None
 
-        result = schedule_generator.generate_schedule_csv(2, 2)
+        result = schedule_generator.generate_schedule(2, 2)
         self.assertEqual(result, "Error: Solver could not be created.")
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- update `generate_schedule` to return matchups directly
- adjust server to consume new schedule format
- update unit and integration tests for new behaviour

## Testing
- `python -m grpc_tools.protoc -Isrc/protos --python_out=src --grpc_python_out=src src/protos/scheduler.proto`
- `export PYTHONPATH=src && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0c18cd9c832e88921c2c6bd5e9ed