### PR TITLE
Support custom division ordering

### DIFF
--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -11,9 +11,15 @@ import scheduler_pb2_grpc
 
 def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     request = scheduler_pb2.ScheduleRequest()
-    for i in range(num_teams):
-        team = scheduler_pb2.Team(name=f"Team {i+1}", division_id=0)
-        request.league.append(team)
+    # Alternate teams between two divisions so ordering does not already match
+    # the solver's expected grouping.
+    for i in range(num_teams // 2):
+        request.league.append(
+            scheduler_pb2.Team(name=f"Division 0 Team {i+1}", division_id=0)
+        )
+        request.league.append(
+            scheduler_pb2.Team(name=f"Division 1 Team {i+1}", division_id=1)
+        )
     return request
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -18,7 +18,12 @@ class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
 
         response = scheduler_pb2.ScheduleResponse()
 
-        num_teams = len(request.league)
+        # Reorder teams so that all teams from the same division are contiguous
+        # in the list passed to the solver. The solver expects the first half of
+        # teams to belong to one division and the rest to another.
+        teams_sorted = sorted(list(request.league), key=lambda t: t.division_id)
+
+        num_teams = len(teams_sorted)
         if num_teams == 0:
             logger.info("No teams provided in request")
             return response
@@ -38,8 +43,10 @@ class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
             weekly = response.matchups.add()
             for team1_idx, team2_idx in schedule.get(week, []):
                 matchup = weekly.matchups.add()
-                matchup.team1.CopyFrom(request.league[team1_idx])
-                matchup.team2.CopyFrom(request.league[team2_idx])
+                # Map the solver indices back to the correct teams using the
+                # sorted order used when invoking the solver.
+                matchup.team1.CopyFrom(teams_sorted[team1_idx])
+                matchup.team2.CopyFrom(teams_sorted[team2_idx])
 
         logger.info(
             "Returning schedule response with %d weeks", len(response.matchups)

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -60,9 +60,15 @@ class TestServerIntegration(unittest.TestCase):
         stub = scheduler_pb2_grpc.SchedulerStub(channel)
 
         request = scheduler_pb2.ScheduleRequest()
-        for i in range(10):
-            team = scheduler_pb2.Team(name=f"Team {i+1}", division_id=0)
-            request.league.append(team)
+        # Create 10 teams split across two divisions but interleaved in the
+        # request to ensure the server reorders them correctly.
+        for i in range(5):
+            request.league.append(
+                scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1)
+            )
+            request.league.append(
+                scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0)
+            )
 
         response = stub.GenerateSchedule(request)
         logging.info("Received response with %d weeks", len(response.matchups))


### PR DESCRIPTION
## Summary
- reorder teams by division when generating schedules
- update server integration test to interleave division order
- adjust example request to mix division teams

## Testing
- `python -m unittest tests/test_schedule_generator.py`
- `PYTHONPATH=src python -m unittest tests/test_integration_schedule_generator.py`
- `PYTHONPATH=src python -m unittest tests/test_integration_server.py`


------
https://chatgpt.com/codex/tasks/task_e_685f10b0989c832eb1ae8339c523a1a6