### PR TITLE
Implement division count validation

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -18,6 +18,17 @@ class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
 
         response = scheduler_pb2.ScheduleResponse()
 
+        # Determine how many unique divisions are present in the request. The
+        # service currently only supports schedules for a single division or for
+        # two divisions. Any other number of divisions is rejected.
+        division_ids = {team.division_id for team in request.league}
+        division_ids.update(div.id for div in request.divisions)
+        if len(division_ids) not in (1, 2):
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "Only 1 or 2 divisions are currently supported",
+            )
+
         # Reorder teams so that all teams from the same division are contiguous
         # in the list passed to the solver. The solver expects the first half of
         # teams to belong to one division and the rest to another.

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -80,6 +80,33 @@ class TestServerIntegration(unittest.TestCase):
 
         channel.close()
 
+    def test_generate_schedule_invalid_divisions(self):
+        """Requests with more than two divisions should return an error."""
+        logging.info("Sending invalid GenerateSchedule request to server")
+        channel = grpc.insecure_channel('localhost:50051')
+        stub = scheduler_pb2_grpc.SchedulerStub(channel)
+
+        request = scheduler_pb2.ScheduleRequest()
+        # Create teams across three divisions to trigger the validation.
+        for i in range(4):
+            request.league.append(
+                scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0)
+            )
+        for i in range(3):
+            request.league.append(
+                scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1)
+            )
+        for i in range(3):
+            request.league.append(
+                scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2)
+            )
+
+        with self.assertRaises(grpc.RpcError) as cm:
+            stub.GenerateSchedule(request)
+        self.assertEqual(cm.exception.code(), grpc.StatusCode.INVALID_ARGUMENT)
+
+        channel.close()
+
 
 if __name__ == '__main__':
     logging.basicConfig(


### PR DESCRIPTION
## Summary
- validate that schedule requests contain only one or two divisions
- add integration test for invalid division counts

## Testing
- `PYTHONPATH=src python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_685f129b66c4832ebf5bd90084a00ffa