### PR TITLE
Add linting and CI integration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           pip install -r requirements.txt
           pip install nox
 
+      - name: Run lint
+        run: nox -s lint
+
       - name: Run unit tests
         run: nox -s test_unit
 

--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -1,12 +1,6 @@
-import sys
-from pathlib import Path
-
-# Ensure the generated gRPC modules are on the path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-
 import grpc
-import scheduler_pb2
-import scheduler_pb2_grpc
+from src import scheduler_pb2
+from src import scheduler_pb2_grpc
 
 
 def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:

--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -14,12 +14,8 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     # Alternate teams between two divisions so ordering does not already match
     # the solver's expected grouping.
     for i in range(num_teams // 2):
-        request.league.append(
-            scheduler_pb2.Team(name=f"Division 0 Team {i+1}", division_id=0)
-        )
-        request.league.append(
-            scheduler_pb2.Team(name=f"Division 1 Team {i+1}", division_id=1)
-        )
+        request.league.append(scheduler_pb2.Team(name=f"Division 0 Team {i+1}", division_id=0))
+        request.league.append(scheduler_pb2.Team(name=f"Division 1 Team {i+1}", division_id=1))
     return request
 
 
@@ -38,4 +34,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 import nox
 
+
 @nox.session(reuse_venv=True)
 def build(session):
     session.install("grpcio-tools")
@@ -12,6 +13,7 @@ def build(session):
         "--grpc_python_out=src",
         "src/protos/scheduler.proto",
     )
+
 
 @nox.session(reuse_venv=True)
 def run(session):
@@ -31,6 +33,7 @@ def run(session):
         env={"PYTHONPATH": "."},
     )
 
+
 @nox.session(reuse_venv=True)
 def test_unit(session):
     session.install("-r", "requirements.txt")
@@ -41,6 +44,7 @@ def test_unit(session):
         "tests/test_schedule_generator.py",
         env={"PYTHONPATH": "src"},
     )
+
 
 @nox.session(reuse_venv=True)
 def test_integration(session):
@@ -54,7 +58,15 @@ def test_integration(session):
         env={"PYTHONPATH": "src"},
     )
 
+
 @nox.session(reuse_venv=True)
 def tests(session):
     session.notify("test_unit")
     session.notify("test_integration")
+
+
+@nox.session(reuse_venv=True)
+def lint(session):
+    """Run flake8 code linting."""
+    session.install("-r", "requirements.txt")
+    session.run("flake8", "src", "tests", "examples", "noxfile.py")

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,4 +69,11 @@ def tests(session):
 def lint(session):
     """Run flake8 code linting."""
     session.install("-r", "requirements.txt")
-    session.run("flake8", "src", "tests", "examples", "noxfile.py")
+    session.run(
+        "flake8",
+        "src",
+        "tests",
+        "examples",
+        "noxfile.py",
+        "--config=.flake8",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 100
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = "E203"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ ortools==9.14.6206
 grpcio==1.73.1
 grpcio-tools==1.73.1
 grpcio-reflection==1.73.1
+flake8==7.0.0
+black==24.4.2

--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -1,22 +1,24 @@
 from ortools.linear_solver import pywraplp
 
+
 # Returns all of the variables in variables that correspond to the given team playing in a game in the given week
 # Excludes variables representing the team playing itself
 def getTeamsVariablesForWeek(variables, team, week, weeks_param, teams_param):
     teamsVariables = []
     for w in weeks_param:
         for i in teams_param:
-            for j in teams_param: 
+            for j in teams_param:
                 if ((i == team) or (j == team)) and (i != j) and (w == week):
                     teamsVariables.append(variables[i][j][w])
     return teamsVariables
+
 
 # Returns all of the variables in variables that represent team 1 playing in team 2 in any week
 def getTeamsVariablesForAllWeeks(variables, team1, team2, weeks_param, teams_param):
     teamsVariables = []
     for w in weeks_param:
         for i in teams_param:
-            for j in teams_param: 
+            for j in teams_param:
                 if ((i == team1) and (j == team2)) or ((i == team2) and (j == team1)):
                     teamsVariables.append(variables[i][j][w])
     return teamsVariables
@@ -24,7 +26,7 @@ def getTeamsVariablesForAllWeeks(variables, team1, team2, weeks_param, teams_par
 
 def _get_schedule_data(variables, weeks_param, teams_param):
     schedule_data = []
-    schedule_data.append(['Week', 'Team1', 'Team2'])
+    schedule_data.append(["Week", "Team1", "Team2"])
     for w in weeks_param:
         for i in teams_param:
             for j in teams_param:
@@ -33,6 +35,7 @@ def _get_schedule_data(variables, weeks_param, teams_param):
                 if (i < j) and (variables[i][j][w].solution_value() > 0):
                     schedule_data.append([w, i, j])
     return schedule_data
+
 
 def generate_schedule(num_weeks, num_teams):
     weeks = range(num_weeks)
@@ -50,10 +53,10 @@ def generate_schedule(num_weeks, num_teams):
     #    if x[i][j][w] == 0, then team i does not play team j in week w
     variables = [[[0 for k in weeks] for j in teams] for i in teams]
     for j in range(num_teams):
-      for k in range(num_teams):
-          for w in range(num_weeks):
-              variables[j][k][w] = solver.IntVar(0, infinity, f"x[{j}][{k}][{w}]")
-    
+        for k in range(num_teams):
+            for w in range(num_weeks):
+                variables[j][k][w] = solver.IntVar(0, infinity, f"x[{j}][{k}][{w}]")
+
     # no team plays itself
     # x[i][i][w] = 0 for each week w, for each team i
     for week in weeks:
@@ -75,27 +78,33 @@ def generate_schedule(num_weeks, num_teams):
     for team in teams:
         for team2 in teams:
             if team > team2:
-              for week in weeks:
-                  constraint = solver.RowConstraint(0, 0, "")
-                  constraint.SetCoefficient(variables[team][team2][week], 1)
-                  constraint.SetCoefficient(variables[team2][team][week], -1)
-    
+                for week in weeks:
+                    constraint = solver.RowConstraint(0, 0, "")
+                    constraint.SetCoefficient(variables[team][team2][week], 1)
+                    constraint.SetCoefficient(variables[team2][team][week], -1)
+
     # Teams within the division play each other twice
     # for each team combination in each division, for all weeks
-    #  sum( x[i][j][w] ) = 4 
+    #  sum( x[i][j][w] ) = 4
     for team in teams:
         for team2 in teams:
-            if (team != team2) and ((team < num_teams/2 and team2 < num_teams/2) or (team >= num_teams/2 and team2 >= num_teams/2)):
+            if (team != team2) and (
+                (team < num_teams / 2 and team2 < num_teams / 2)
+                or (team >= num_teams / 2 and team2 >= num_teams / 2)
+            ):
                 constraint = solver.RowConstraint(4, 4, "")
                 for variable in getTeamsVariablesForAllWeeks(variables, team, team2, weeks, teams):
                     constraint.SetCoefficient(variable, 1)
 
     # Teams play out of division opponents once
     # for each team combination outside each division, for all weeks
-    #  sum( x[i][j][w] ) = 2 
+    #  sum( x[i][j][w] ) = 2
     for team in teams:
         for team2 in teams:
-            if (team != team2) and not ((team < num_teams/2 and team2 < num_teams/2) or (team >= num_teams/2 and team2 >= num_teams/2)):
+            if (team != team2) and not (
+                (team < num_teams / 2 and team2 < num_teams / 2)
+                or (team >= num_teams / 2 and team2 >= num_teams / 2)
+            ):
                 constraint = solver.RowConstraint(2, 2, "")
                 for variable in getTeamsVariablesForAllWeeks(variables, team, team2, weeks, teams):
                     constraint.SetCoefficient(variable, 1)
@@ -107,16 +116,19 @@ def generate_schedule(num_weeks, num_teams):
                 if team > team2:
                     constraint = solver.RowConstraint(0, 1, "")
                     constraint.SetCoefficient(variables[team][team2][week], 1)
-                    constraint.SetCoefficient(variables[team][team2][week+1], 1)
-                    constraint.SetCoefficient(variables[team][team2][week+2], 1)
-                    constraint.SetCoefficient(variables[team][team2][week+3], 1)
+                    constraint.SetCoefficient(variables[team][team2][week + 1], 1)
+                    constraint.SetCoefficient(variables[team][team2][week + 2], 1)
+                    constraint.SetCoefficient(variables[team][team2][week + 3], 1)
 
     # Try your best to not schedule out of division games for the last 2 weeks
     # (to avoid potential rematches in week 14)
     objective = solver.Objective()
     for team in teams:
         for team2 in teams:
-            if (team != team2) and ((team < num_teams/2 and team2 < num_teams/2) or (team >= num_teams/2 and team2 >= num_teams/2)):
+            if (team != team2) and (
+                (team < num_teams / 2 and team2 < num_teams / 2)
+                or (team >= num_teams / 2 and team2 >= num_teams / 2)
+            ):
                 objective.SetCoefficient(variables[team][team2][-1], 1)
                 objective.SetCoefficient(variables[team][team2][-2], 1)
     objective.SetMaximization()
@@ -129,12 +141,14 @@ def generate_schedule(num_weeks, num_teams):
     else:
         return "The problem does not have an optimal solution."
 
+
 def main():
     # Default values for weeks and teams
     default_weeks = 13
     default_teams = 10
     schedule_data = generate_schedule(default_weeks, default_teams)
     print(schedule_data)
+
 
 if __name__ == "__main__":
     main()

--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -1,7 +1,8 @@
 from ortools.linear_solver import pywraplp
 
 
-# Returns all of the variables in variables that correspond to the given team playing in a game in the given week
+# Returns all of the variables in variables that correspond to the
+# given team playing in a game in the given week
 # Excludes variables representing the team playing itself
 def getTeamsVariablesForWeek(variables, team, week, weeks_param, teams_param):
     teamsVariables = []

--- a/src/server.py
+++ b/src/server.py
@@ -10,11 +10,10 @@ from src import schedule_generator
 
 logger = logging.getLogger(__name__)
 
+
 class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
     def GenerateSchedule(self, request, context):
-        logger.info(
-            "GenerateSchedule request received with %d teams", len(request.league)
-        )
+        logger.info("GenerateSchedule request received with %d teams", len(request.league))
 
         response = scheduler_pb2.ScheduleResponse()
 
@@ -59,16 +58,15 @@ class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
                 matchup.team1.CopyFrom(teams_sorted[team1_idx])
                 matchup.team2.CopyFrom(teams_sorted[team2_idx])
 
-        logger.info(
-            "Returning schedule response with %d weeks", len(response.matchups)
-        )
+        logger.info("Returning schedule response with %d weeks", len(response.matchups))
 
         return response
+
 
 def serve():
     logging.basicConfig(
         level=logging.INFO,
-        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
@@ -76,15 +74,16 @@ def serve():
 
     # Enable reflection
     SERVICE_NAMES = (
-        scheduler_pb2.DESCRIPTOR.services_by_name['Scheduler'].full_name,
+        scheduler_pb2.DESCRIPTOR.services_by_name["Scheduler"].full_name,
         reflection.SERVICE_NAME,
     )
     reflection.enable_server_reflection(SERVICE_NAMES, server)
 
-    server.add_insecure_port('[::]:50051')
+    server.add_insecure_port("[::]:50051")
     server.start()
     logger.info("Server started on port 50051 with reflection enabled")
     server.wait_for_termination()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     serve()

--- a/tests/test_integration_schedule_generator.py
+++ b/tests/test_integration_schedule_generator.py
@@ -2,6 +2,7 @@ import unittest
 import logging
 import schedule_generator
 
+
 class TestScheduleGeneratorIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -11,7 +12,7 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
 
         logging.basicConfig(
             level=logging.INFO,
-            format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+            format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
         )
         logging.info(
             "Calling generate_schedule with %d weeks and %d teams",
@@ -19,13 +20,9 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
             cls.num_teams,
         )
 
-        cls.schedule_data = schedule_generator.generate_schedule(
-            cls.num_weeks, cls.num_teams
-        )
+        cls.schedule_data = schedule_generator.generate_schedule(cls.num_weeks, cls.num_teams)
 
-        logging.info(
-            "generate_schedule returned %d rows", len(cls.schedule_data)
-        )
+        logging.info("generate_schedule returned %d rows", len(cls.schedule_data))
 
     def test_generate_schedule_real_solver(self):
         """Basic sanity checks on the solver output."""
@@ -76,9 +73,10 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
                     msg=f"Pair {pair} repeats within {diff} weeks",
                 )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
-        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
     unittest.main()

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -5,35 +5,36 @@ import unittest
 import subprocess
 from multiprocessing import Process
 import logging
+import importlib
 
 import grpc
 
-# Compile protobuf definitions before importing the server
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-subprocess.check_call(
-    [
-        sys.executable,
-        "-m",
-        "grpc_tools.protoc",
-        "-Isrc/protos",
-        "--python_out=src",
-        "--grpc_python_out=src",
-        "src/protos/scheduler.proto",
-    ],
-    cwd=ROOT_DIR,
-)
-
-import scheduler_pb2
-import scheduler_pb2_grpc
-import server
 
 
-def _run_server():
+def _compile_protos() -> None:
+    """Compile protobuf definitions for the tests."""
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "grpc_tools.protoc",
+            "-Isrc/protos",
+            "--python_out=src",
+            "--grpc_python_out=src",
+            "src/protos/scheduler.proto",
+        ],
+        cwd=ROOT_DIR,
+    )
+
+
+def _run_server() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
     logging.info("Starting server in subprocess for integration test")
+    server = importlib.import_module("server")
     server.serve()
 
 
@@ -44,6 +45,10 @@ class TestServerIntegration(unittest.TestCase):
             level=logging.INFO,
             format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
         )
+        _compile_protos()
+        global scheduler_pb2, scheduler_pb2_grpc
+        scheduler_pb2 = importlib.import_module("scheduler_pb2")
+        scheduler_pb2_grpc = importlib.import_module("scheduler_pb2_grpc")
         logging.info("Launching gRPC server process for integration test")
         cls.proc = Process(target=_run_server)
         cls.proc.start()

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -9,15 +9,19 @@ import logging
 import grpc
 
 # Compile protobuf definitions before importing the server
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-subprocess.check_call([
-    sys.executable,
-    '-m', 'grpc_tools.protoc',
-    '-Isrc/protos',
-    '--python_out=src',
-    '--grpc_python_out=src',
-    'src/protos/scheduler.proto'
-], cwd=ROOT_DIR)
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+subprocess.check_call(
+    [
+        sys.executable,
+        "-m",
+        "grpc_tools.protoc",
+        "-Isrc/protos",
+        "--python_out=src",
+        "--grpc_python_out=src",
+        "src/protos/scheduler.proto",
+    ],
+    cwd=ROOT_DIR,
+)
 
 import scheduler_pb2
 import scheduler_pb2_grpc
@@ -27,7 +31,7 @@ import server
 def _run_server():
     logging.basicConfig(
         level=logging.INFO,
-        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
     logging.info("Starting server in subprocess for integration test")
     server.serve()
@@ -38,7 +42,7 @@ class TestServerIntegration(unittest.TestCase):
     def setUpClass(cls):
         logging.basicConfig(
             level=logging.INFO,
-            format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+            format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
         )
         logging.info("Launching gRPC server process for integration test")
         cls.proc = Process(target=_run_server)
@@ -56,19 +60,15 @@ class TestServerIntegration(unittest.TestCase):
 
     def test_generate_schedule_returns_matchups(self):
         logging.info("Sending GenerateSchedule request to server")
-        channel = grpc.insecure_channel('localhost:50051')
+        channel = grpc.insecure_channel("localhost:50051")
         stub = scheduler_pb2_grpc.SchedulerStub(channel)
 
         request = scheduler_pb2.ScheduleRequest()
         # Create 10 teams split across two divisions but interleaved in the
         # request to ensure the server reorders them correctly.
         for i in range(5):
-            request.league.append(
-                scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1)
-            )
-            request.league.append(
-                scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0)
-            )
+            request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
+            request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
 
         response = stub.GenerateSchedule(request)
         logging.info("Received response with %d weeks", len(response.matchups))
@@ -83,23 +83,17 @@ class TestServerIntegration(unittest.TestCase):
     def test_generate_schedule_invalid_divisions(self):
         """Requests with more than two divisions should return an error."""
         logging.info("Sending invalid GenerateSchedule request to server")
-        channel = grpc.insecure_channel('localhost:50051')
+        channel = grpc.insecure_channel("localhost:50051")
         stub = scheduler_pb2_grpc.SchedulerStub(channel)
 
         request = scheduler_pb2.ScheduleRequest()
         # Create teams across three divisions to trigger the validation.
         for i in range(4):
-            request.league.append(
-                scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0)
-            )
+            request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
         for i in range(3):
-            request.league.append(
-                scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1)
-            )
+            request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
         for i in range(3):
-            request.league.append(
-                scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2)
-            )
+            request.league.append(scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2))
 
         with self.assertRaises(grpc.RpcError) as cm:
             stub.GenerateSchedule(request)
@@ -108,9 +102,9 @@ class TestServerIntegration(unittest.TestCase):
         channel.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
-        format='[%(asctime)s] %(levelname)s %(name)s: %(message)s',
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
     unittest.main()

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import Mock, patch
 from src import schedule_generator
 
+
 class TestScheduleGenerator(unittest.TestCase):
 
     def setUp(self):
@@ -10,41 +11,53 @@ class TestScheduleGenerator(unittest.TestCase):
         self.weeks = range(self.num_weeks)
         self.teams = range(self.num_teams)
         # Create a mock 3D array of variables for testing
-        self.mock_variables = [[[f'var_{i}_{j}_{w}' for w in self.weeks] for j in self.teams] for i in self.teams]
+        self.mock_variables = [
+            [[f"var_{i}_{j}_{w}" for w in self.weeks] for j in self.teams] for i in self.teams
+        ]
 
     def test_getTeamsVariablesForWeek(self):
         # Test for team 3, week 5
-        result = schedule_generator.getTeamsVariablesForWeek(self.mock_variables, 3, 5, self.weeks, self.teams)
-        
+        result = schedule_generator.getTeamsVariablesForWeek(
+            self.mock_variables, 3, 5, self.weeks, self.teams
+        )
+
         expected_vars = []
         for team2 in self.teams:
             if team2 != 3:
-                expected_vars.append(f'var_3_{team2}_5')
-                expected_vars.append(f'var_{team2}_3_5')
-        
+                expected_vars.append(f"var_3_{team2}_5")
+                expected_vars.append(f"var_{team2}_3_5")
+
         self.assertCountEqual(result, expected_vars)
 
         # Test with a team that doesn't exist
-        result_invalid_team = schedule_generator.getTeamsVariablesForWeek(self.mock_variables, 99, 5, self.weeks, self.teams)
+        result_invalid_team = schedule_generator.getTeamsVariablesForWeek(
+            self.mock_variables, 99, 5, self.weeks, self.teams
+        )
         self.assertEqual(result_invalid_team, [])
 
         # Test with a week that doesn't exist
-        result_invalid_week = schedule_generator.getTeamsVariablesForWeek(self.mock_variables, 3, 99, self.weeks, self.teams)
+        result_invalid_week = schedule_generator.getTeamsVariablesForWeek(
+            self.mock_variables, 3, 99, self.weeks, self.teams
+        )
         self.assertEqual(result_invalid_week, [])
 
     def test_getTeamsVariablesForAllWeeks(self):
         # Test for team 1 vs team 8
-        result = schedule_generator.getTeamsVariablesForAllWeeks(self.mock_variables, 1, 8, self.weeks, self.teams)
-        
+        result = schedule_generator.getTeamsVariablesForAllWeeks(
+            self.mock_variables, 1, 8, self.weeks, self.teams
+        )
+
         expected_vars = []
         for w in self.weeks:
-            expected_vars.append(f'var_1_8_{w}')
-            expected_vars.append(f'var_8_1_{w}')
+            expected_vars.append(f"var_1_8_{w}")
+            expected_vars.append(f"var_8_1_{w}")
 
         self.assertCountEqual(result, expected_vars)
 
         # Test with teams that don't exist
-        result_invalid_teams = schedule_generator.getTeamsVariablesForAllWeeks(self.mock_variables, 99, 100, self.weeks, self.teams)
+        result_invalid_teams = schedule_generator.getTeamsVariablesForAllWeeks(
+            self.mock_variables, 99, 100, self.weeks, self.teams
+        )
         self.assertEqual(result_invalid_teams, [])
 
     def test_get_schedule_data_no_duplicate_matchups(self):
@@ -58,7 +71,7 @@ class TestScheduleGenerator(unittest.TestCase):
 
         schedule_data = schedule_generator._get_schedule_data(variables, weeks_param, teams_param)
 
-        expected = [['Week', 'Team1', 'Team2'], [0, 0, 1]]
+        expected = [["Week", "Team1", "Team2"], [0, 0, 1]]
         self.assertEqual(schedule_data, expected)
 
     def test_get_schedule_data_returns_expected_rows(self):
@@ -78,13 +91,13 @@ class TestScheduleGenerator(unittest.TestCase):
         schedule_data = schedule_generator._get_schedule_data(variables, weeks_param, teams_param)
 
         expected = [
-            ['Week', 'Team1', 'Team2'],
+            ["Week", "Team1", "Team2"],
             [0, 0, 1],
             [1, 1, 2],
         ]
         self.assertEqual(schedule_data, expected)
 
-    @patch('src.schedule_generator.pywraplp.Solver')
+    @patch("src.schedule_generator.pywraplp.Solver")
     def test_generate_schedule_optimal_solution(self, MockSolver):
         mock_solver_instance = Mock()
         MockSolver.CreateSolver.return_value = mock_solver_instance
@@ -92,7 +105,7 @@ class TestScheduleGenerator(unittest.TestCase):
         # Mock solver behavior for optimal solution
         mock_solver_instance.Solve.return_value = schedule_generator.pywraplp.Solver.OPTIMAL
         mock_solver_instance.Objective.return_value.Value.return_value = 0
-        
+
         # Mock variables with solution values
         mock_variables_solution = [[[Mock() for _ in range(2)] for _ in range(2)] for _ in range(2)]
         mock_variables_solution[0][1][0].solution_value.return_value = 1
@@ -101,26 +114,20 @@ class TestScheduleGenerator(unittest.TestCase):
         mock_variables_solution[1][0][1].solution_value.return_value = 1
 
         # Patch the internal _get_schedule_data to return a predictable schedule
-        with patch('src.schedule_generator._get_schedule_data') as mock_get_schedule_data:
+        with patch("src.schedule_generator._get_schedule_data") as mock_get_schedule_data:
             mock_get_schedule_data.return_value = [
-                ['Week', 'Team1', 'Team2'],
+                ["Week", "Team1", "Team2"],
                 [0, 0, 1],
                 [0, 1, 0],
                 [1, 0, 1],
-                [1, 1, 0]
+                [1, 1, 0],
             ]
             result = schedule_generator.generate_schedule(2, 2)
 
-        expected = [
-            ['Week', 'Team1', 'Team2'],
-            [0, 0, 1],
-            [0, 1, 0],
-            [1, 0, 1],
-            [1, 1, 0]
-        ]
+        expected = [["Week", "Team1", "Team2"], [0, 0, 1], [0, 1, 0], [1, 0, 1], [1, 1, 0]]
         self.assertEqual(result, expected)
 
-    @patch('src.schedule_generator.pywraplp.Solver')
+    @patch("src.schedule_generator.pywraplp.Solver")
     def test_generate_schedule_no_optimal_solution(self, MockSolver):
         mock_solver_instance = Mock()
         MockSolver.CreateSolver.return_value = mock_solver_instance
@@ -131,12 +138,13 @@ class TestScheduleGenerator(unittest.TestCase):
         result = schedule_generator.generate_schedule(2, 2)
         self.assertEqual(result, "The problem does not have an optimal solution.")
 
-    @patch('src.schedule_generator.pywraplp.Solver')
+    @patch("src.schedule_generator.pywraplp.Solver")
     def test_generate_schedule_solver_creation_failure(self, MockSolver):
         MockSolver.CreateSolver.return_value = None
 
         result = schedule_generator.generate_schedule(2, 2)
         self.assertEqual(result, "Error: Solver could not be created.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- configure black/flake8 with 100-char line length
- install lint tooling
- add lint job to CI workflow
- reformat code with black

## Testing
- `PYTHONPATH=src python -m unittest discover tests`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f17627a74832e98fcaf207ce2409f