### PR TITLE
Fix example script imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ same request in action:
 
 ```bash
 nox -s build
-python examples/example_request.py
+PYTHONPATH=.:src python examples/example_request.py
 ```


### PR DESCRIPTION
## Summary
- remove sys.path hacks from example
- instruct users to extend `PYTHONPATH` when running the example

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=.:src python examples/example_request.py` *(fails to connect as server isn't running but import works)*

------
https://chatgpt.com/codex/tasks/task_e_685f1f2532b0832eaf3f01ddf37f047b