### PR TITLE
Add Dockerfile for gRPC server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore git and build artifacts
+.git
+.gitignore
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.dylib
+*.egg-info/
+*.pytest_cache/
+.nox/
+.venv/
+venv/
+*.csv
+schedule.csv
+examples/
+tests/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Compile protobufs
+RUN python -m grpc_tools.protoc -Isrc/protos --python_out=src --grpc_python_out=src src/protos/scheduler.proto
+
+# Set PYTHONPATH so the server can find the generated modules
+ENV PYTHONPATH=/app
+
+EXPOSE 50051
+
+CMD ["python", "src/server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY src ./src
 
 # Compile protobufs
-RUN python -m grpc_tools.protoc -Isrc/protos --python_out=src --grpc_python_out=src src/protos/scheduler.proto
+COPY compile_protos.py ./
+RUN python compile_protos.py
 
 # Set PYTHONPATH so the server can find the generated modules
 ENV PYTHONPATH=/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy project files
-COPY . .
+# Copy only source code and protos
+COPY src ./src
 
 # Compile protobufs
 RUN python -m grpc_tools.protoc -Isrc/protos --python_out=src --grpc_python_out=src src/protos/scheduler.proto

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ PYTHONPATH=.:src python examples/example_request.py
 
 ## Docker
 
-A `Dockerfile` is provided for building the server into a container image. Build the image and run it locally with:
+A `Dockerfile` is provided for building the server into a container image. A
+`.dockerignore` file excludes development artifacts so the image stays small.
+Build the image and run it locally with:
 
 ```bash
 docker build -t schedule-server .

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ pip install nox
 
 ## Build
 
-The server uses gRPC for communication, with the service interface defined in `scheduler.proto`. Before running the server, you need to compile the protobuf file to generate the Python gRPC code.
+The server uses gRPC for communication. All protobuf definitions in `src/protos` must be compiled before the server can run. A helper script `compile_protos.py` handles this for every `.proto` file found in that directory.
 
 ```bash
 nox -s build
 ```
 
-This will create `scheduler_pb2.py` and `scheduler_pb2_grpc.py` in the project root.
+This will create the generated `_pb2.py` files next to your source code. You can also run `python compile_protos.py` directly if you prefer not to use Nox.
 
 ## Running the Server
 
@@ -74,3 +74,4 @@ docker run -p 50051:50051 schedule-server
 ```
 
 The image compiles the protobuf definitions during build and starts the gRPC server on port `50051`.
+The `compile_protos.py` script is copied into the image so that any new `.proto` files will be included automatically.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,14 @@ same request in action:
 nox -s build
 PYTHONPATH=.:src python examples/example_request.py
 ```
+
+## Docker
+
+A `Dockerfile` is provided for building the server into a container image. Build the image and run it locally with:
+
+```bash
+docker build -t schedule-server .
+docker run -p 50051:50051 schedule-server
+```
+
+The image compiles the protobuf definitions during build and starts the gRPC server on port `50051`.

--- a/compile_protos.py
+++ b/compile_protos.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from grpc_tools import protoc
+
+PROTO_DIR = Path("src/protos")
+OUT_DIR = Path("src")
+
+proto_files = [str(p) for p in PROTO_DIR.glob("*.proto")]
+
+if not proto_files:
+    raise SystemExit("No .proto files found")
+
+protoc_args = [
+    "grpc_tools.protoc",
+    f"-I{PROTO_DIR}",
+    f"--python_out={OUT_DIR}",
+    f"--grpc_python_out={OUT_DIR}",
+] + proto_files
+
+protoc.main(protoc_args)

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,29 +4,13 @@ import nox
 @nox.session(reuse_venv=True)
 def build(session):
     session.install("grpcio-tools")
-    session.run(
-        "python",
-        "-m",
-        "grpc_tools.protoc",
-        "-Isrc/protos",
-        "--python_out=src",
-        "--grpc_python_out=src",
-        "src/protos/scheduler.proto",
-    )
+    session.run("python", "compile_protos.py")
 
 
 @nox.session(reuse_venv=True)
 def run(session):
     session.install("-r", "requirements.txt")
-    session.run(
-        "python",
-        "-m",
-        "grpc_tools.protoc",
-        "-Isrc/protos",
-        "--python_out=src",
-        "--grpc_python_out=src",
-        "src/protos/scheduler.proto",
-    )
+    session.run("python", "compile_protos.py")
     session.run(
         "python",
         "src/server.py",

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -14,18 +14,10 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 def _compile_protos() -> None:
     """Compile protobuf definitions for the tests."""
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "grpc_tools.protoc",
-            "-Isrc/protos",
-            "--python_out=src",
-            "--grpc_python_out=src",
-            "src/protos/scheduler.proto",
-        ],
-        cwd=ROOT_DIR,
-    )
+    subprocess.check_call([
+        sys.executable,
+        "compile_protos.py",
+    ], cwd=ROOT_DIR)
 
 
 def _run_server() -> None:


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running the gRPC server
- document Docker usage in README

## Testing
- `nox -s tests` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687aaaa2fae4832e825cad6a8c4918a2