### PR TITLE
Allow example request to specify server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ import grpc
 import scheduler_pb2
 import scheduler_pb2_grpc
 
-channel = grpc.insecure_channel('localhost:50051')
+host = 'localhost'  # replace with your server's IP to test remotely
+channel = grpc.insecure_channel(f'{host}:50051')
 stub = scheduler_pb2_grpc.SchedulerStub(channel)
 
 request = scheduler_pb2.ScheduleRequest()
@@ -55,11 +56,11 @@ print(response)
 Ensure the protobuf files are built (`nox -s build`) so that `scheduler_pb2` and `scheduler_pb2_grpc` are available before running the snippet.
 
 You can also run the example script in `examples/example_request.py` to see the
-same request in action:
+same request in action. Pass the server IP if it is not running locally:
 
 ```bash
 nox -s build
-PYTHONPATH=.:src python examples/example_request.py
+PYTHONPATH=.:src python examples/example_request.py 192.168.1.50
 ```
 
 ## Docker

--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -1,3 +1,4 @@
+import argparse
 import grpc
 from src import scheduler_pb2
 from src import scheduler_pb2_grpc
@@ -13,8 +14,10 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     return request
 
 
-def main() -> None:
-    channel = grpc.insecure_channel("localhost:50051")
+def main(host: str = "localhost") -> None:
+    """Send an example schedule request to the server."""
+
+    channel = grpc.insecure_channel(f"{host}:50051")
     stub = scheduler_pb2_grpc.SchedulerStub(channel)
 
     request = build_request(10)
@@ -27,4 +30,12 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Send an example ScheduleRequest")
+    parser.add_argument(
+        "host",
+        nargs="?",
+        default="localhost",
+        help="IP or hostname of the running gRPC server (default: localhost)",
+    )
+    args = parser.parse_args()
+    main(args.host)


### PR DESCRIPTION
## Summary
- update `examples/example_request.py` to accept an optional host argument
- document how to specify a custom host in the README

## Testing
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687ab7f0f3c0832eb54fa05f4eea2c9d