### PR TITLE
Fix(deploy): extend token lifetime in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'
         with:
+          token_format: 'access_token'
+          access_token_lifetime: '3600s'
           workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/githubdeploy/providers/github'
           service_account: 'app-engine-deployer@ff-scheduler-466320.iam.gserviceaccount.com'
 


### PR DESCRIPTION
The deploy workflow was failing because the Google Cloud authentication token was expiring before the `gcloud app deploy` command could complete. This change extends the token lifetime to 1 hour to prevent this from happening.