### PR TITLE
Add health endpoints for GCP compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN python compile_protos.py
 # Set PYTHONPATH so the server can find the generated modules
 ENV PYTHONPATH=/app
 
-EXPOSE 50051
+EXPOSE 50051 8080
 
 CMD ["python", "src/server.py"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ To run the gRPC server, use the following command:
 nox -s run
 ```
 
-The server will start on port `50051`.
+The server will start on port `50051`. An additional HTTP server listens on
+port `8080` and exposes simple health endpoints used by GCP App Engine:
+
+* `/health`
+* `/readiness`
+
+Both endpoints return `200 OK` with the body `"ok"`.
 
 ## Example Request
 

--- a/src/server.py
+++ b/src/server.py
@@ -1,5 +1,8 @@
 from concurrent import futures
 import logging
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
 import grpc
 from grpc_reflection.v1alpha import reflection
 
@@ -9,6 +12,20 @@ from src import schedule_generator
 
 
 logger = logging.getLogger(__name__)
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """Simple HTTP handler for health and readiness checks."""
+
+    def do_GET(self) -> None:  # noqa: D401 -- required method signature
+        if self.path in ("/health", "/readiness", "/_ah/health", "/_ah/readiness"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
 
 
 class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
@@ -68,6 +85,11 @@ def serve():
         level=logging.INFO,
         format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
+
+    # Start HTTP health server on port 8080 in a separate thread
+    httpd = HTTPServer(("0.0.0.0", 8080), HealthHandler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    logger.info("Health server started on port 8080")
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     scheduler_pb2_grpc.add_SchedulerServicer_to_server(SchedulerServicer(), server)

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -6,6 +6,7 @@ import subprocess
 import logging
 import importlib
 import shutil
+import urllib.request
 
 import grpc
 
@@ -55,6 +56,8 @@ def _run_container() -> subprocess.Popen:
         CONTAINER_NAME,
         "-p",
         "50051:50051",
+        "-p",
+        "8080:8080",
         "--rm",
         DOCKER_IMAGE,
     ], cwd=ROOT_DIR)
@@ -119,6 +122,15 @@ class TestServerIntegration(unittest.TestCase):
             self.assertEqual(len(weekly.matchups), 5)
 
         channel.close()
+
+    def test_health_endpoints(self):
+        """Verify health and readiness endpoints return 200."""
+        for path in ("health", "readiness"):
+            url = f"http://localhost:8080/{path}"
+            with urllib.request.urlopen(url) as resp:
+                body = resp.read().decode()
+                self.assertEqual(resp.getcode(), 200)
+                self.assertEqual(body, "ok")
 
     def test_generate_schedule_invalid_divisions(self):
         """Requests with more than two divisions should return an error."""


### PR DESCRIPTION
## Summary
- expose `/health` and `/readiness` endpoints for GCP App Engine
- listen on port 8080 for health checks and update Dockerfile
- verify endpoints in integration tests

## Testing
- `nox -s build`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687e70142188832e9ce696fa15ce9d7e