### PR TITLE
Update health endpoint names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ nox -s run
 The server will start on port `50051`. An additional HTTP server listens on
 port `8080` and exposes simple health endpoints used by GCP App Engine:
 
-* `/health`
-* `/readiness`
+* `/liveness_check`
+* `/readiness_check`
 
 Both endpoints return `200 OK` with the body `"ok"`.
 

--- a/src/server.py
+++ b/src/server.py
@@ -18,7 +18,12 @@ class HealthHandler(BaseHTTPRequestHandler):
     """Simple HTTP handler for health and readiness checks."""
 
     def do_GET(self) -> None:  # noqa: D401 -- required method signature
-        if self.path in ("/health", "/readiness", "/_ah/health", "/_ah/readiness"):
+        if self.path in (
+            "/liveness_check",
+            "/readiness_check",
+            "/_ah/liveness_check",
+            "/_ah/readiness_check",
+        ):
             self.send_response(200)
             self.send_header("Content-Type", "text/plain")
             self.end_headers()

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -125,7 +125,7 @@ class TestServerIntegration(unittest.TestCase):
 
     def test_health_endpoints(self):
         """Verify health and readiness endpoints return 200."""
-        for path in ("health", "readiness"):
+        for path in ("liveness_check", "readiness_check"):
             url = f"http://localhost:8080/{path}"
             with urllib.request.urlopen(url) as resp:
                 body = resp.read().decode()


### PR DESCRIPTION
## Summary
- serve health endpoint at `/liveness_check`
- serve readiness endpoint at `/readiness_check`
- update tests and docs

## Testing
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687e83eeda14832ebcb2e344dde7cafb