### PR TITLE
Switch server from gRPC to HTTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN python compile_protos.py
 # Set PYTHONPATH so the server can find the generated modules
 ENV PYTHONPATH=/app
 
-EXPOSE 50051 8080
+EXPOSE 8080
 
 CMD ["python", "src/server.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fantasy Football Schedule Generator
 
-This project contains a gRPC server for generating fantasy football schedules.
+This project contains an HTTP server for generating fantasy football schedules.
 
 ## Installation
 
@@ -13,7 +13,10 @@ pip install nox
 
 ## Build
 
-The server uses gRPC for communication. All protobuf definitions in `src/protos` must be compiled before the server can run. A helper script `compile_protos.py` handles this for every `.proto` file found in that directory.
+The API exchanges JSON payloads, but request and response schemas are defined
+by protobuf. All definitions in `src/protos` must be compiled before the server
+can run. A helper script `compile_protos.py` handles this for every `.proto`
+file found in that directory.
 
 ```bash
 nox -s build
@@ -23,14 +26,13 @@ This will create the generated `_pb2.py` files next to your source code. You can
 
 ## Running the Server
 
-To run the gRPC server, use the following command:
+To run the HTTP server, use the following command:
 
 ```bash
 nox -s run
 ```
 
-The server will start on port `50051`. An additional HTTP server listens on
-port `8080` and exposes simple health endpoints used by GCP App Engine:
+The server listens on port `8080` and exposes health endpoints used by GCP App Engine:
 
 * `/liveness_check`
 * `/readiness_check`
@@ -39,27 +41,36 @@ Both endpoints return `200 OK` with the body `"ok"`.
 
 ## Example Request
 
-After starting the server, you can send a gRPC request to it using Python. The snippet below builds a `ScheduleRequest` with ten teams and prints the generated schedule.
+After starting the server, you can send an HTTP request to it using Python. The
+snippet below builds a `ScheduleRequest` with ten teams and prints the generated
+schedule.
 
 ```python
-import grpc
+import json
+import urllib.request
+from google.protobuf import json_format
 import scheduler_pb2
-import scheduler_pb2_grpc
-
-host = 'localhost'  # replace with your server's IP to test remotely
-channel = grpc.insecure_channel(f'{host}:50051')
-stub = scheduler_pb2_grpc.SchedulerStub(channel)
 
 request = scheduler_pb2.ScheduleRequest()
 for i in range(10):
     team = scheduler_pb2.Team(name=f'Team {i+1}', division_id=0)
     request.league.append(team)
 
-response = stub.GenerateSchedule(request)
-print(response)
+req_dict = json_format.MessageToDict(request, preserving_proto_field_name=True)
+data = json.dumps(req_dict).encode()
+http_req = urllib.request.Request(
+    'http://localhost:8080/generate-schedule',
+    data=data,
+    headers={'Content-Type': 'application/json'}
+)
+with urllib.request.urlopen(http_req) as resp:
+    response_data = json.load(resp)
+
+print(response_data)
 ```
 
-Ensure the protobuf files are built (`nox -s build`) so that `scheduler_pb2` and `scheduler_pb2_grpc` are available before running the snippet.
+Ensure the protobuf files are built (`nox -s build`) so that `scheduler_pb2` is
+available before running the snippet.
 
 You can also run the example script in `examples/example_request.py` to see the
 same request in action. Pass the server IP if it is not running locally:
@@ -77,8 +88,8 @@ Build the image and run it locally with:
 
 ```bash
 docker build -t schedule-server .
-docker run -p 50051:50051 schedule-server
+docker run -p 8080:8080 schedule-server
 ```
 
-The image compiles the protobuf definitions during build and starts the gRPC server on port `50051`.
+The image compiles the protobuf definitions during build and starts the HTTP server on port `8080`.
 The `compile_protos.py` script is copied into the image so that any new `.proto` files will be included automatically.

--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -1,7 +1,8 @@
 import argparse
-import grpc
+import json
+import urllib.request
+from google.protobuf import json_format
 from src import scheduler_pb2
-from src import scheduler_pb2_grpc
 
 
 def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
@@ -15,13 +16,21 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
 
 
 def main(host: str = "localhost") -> None:
-    """Send an example schedule request to the server."""
+    """Send an example schedule request to the HTTP server."""
 
-    channel = grpc.insecure_channel(f"{host}:50051")
-    stub = scheduler_pb2_grpc.SchedulerStub(channel)
-
+    url = f"http://{host}:8080/generate-schedule"
     request = build_request(10)
-    response = stub.GenerateSchedule(request)
+    req_dict = json_format.MessageToDict(
+        request, preserving_proto_field_name=True
+    )
+    data = json.dumps(req_dict).encode()
+    http_req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(http_req) as resp:
+        resp_data = json.load(resp)
+
+    response = json_format.ParseDict(resp_data, scheduler_pb2.ScheduleResponse())
 
     for week_idx, weekly in enumerate(response.matchups, start=1):
         print(f"Week {week_idx}")
@@ -35,7 +44,7 @@ if __name__ == "__main__":
         "host",
         nargs="?",
         default="localhost",
-        help="IP or hostname of the running gRPC server (default: localhost)",
+        help="IP or hostname of the running HTTP server (default: localhost)",
     )
     args = parser.parse_args()
     main(args.host)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ ortools==9.14.6206
 grpcio==1.73.1
 grpcio-tools==1.73.1
 grpcio-reflection==1.73.1
+Flask==3.0.3
 flake8==7.0.0
 black==24.4.2

--- a/src/server.py
+++ b/src/server.py
@@ -1,120 +1,88 @@
-from concurrent import futures
 import logging
-import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
 
-import grpc
-from grpc_reflection.v1alpha import reflection
+from flask import Flask, jsonify, request
+from google.protobuf import json_format
 
 import src.scheduler_pb2 as scheduler_pb2
-import src.scheduler_pb2_grpc as scheduler_pb2_grpc
 from src import schedule_generator
 
-
 logger = logging.getLogger(__name__)
+app = Flask(__name__)
 
 
-class HealthHandler(BaseHTTPRequestHandler):
-    """Simple HTTP handler for health and readiness checks."""
+def build_schedule_response(
+    req: scheduler_pb2.ScheduleRequest,
+) -> scheduler_pb2.ScheduleResponse:
+    logger.info("GenerateSchedule request received with %d teams", len(req.league))
 
-    def do_GET(self) -> None:  # noqa: D401 -- required method signature
-        if self.path == "/":
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.end_headers()
-            self.wfile.write(b"OK")
-        elif self.path in (
-            "/liveness_check",
-            "/readiness_check",
-            "/_ah/liveness_check",
-            "/_ah/readiness_check",
-        ):
-            self.send_response(200)
-            self.send_header("Content-Type", "text/plain")
-            self.end_headers()
-            self.wfile.write(b"ok")
-        else:
-            self.send_response(404)
-            self.end_headers()
+    response = scheduler_pb2.ScheduleResponse()
 
+    division_ids = {team.division_id for team in req.league}
+    division_ids.update(div.id for div in req.divisions)
+    if len(division_ids) not in (1, 2):
+        raise ValueError("Only 1 or 2 divisions are currently supported")
 
-class SchedulerServicer(scheduler_pb2_grpc.SchedulerServicer):
-    def GenerateSchedule(self, request, context):
-        logger.info("GenerateSchedule request received with %d teams", len(request.league))
-
-        response = scheduler_pb2.ScheduleResponse()
-
-        # Determine how many unique divisions are present in the request. The
-        # service currently only supports schedules for a single division or for
-        # two divisions. Any other number of divisions is rejected.
-        division_ids = {team.division_id for team in request.league}
-        division_ids.update(div.id for div in request.divisions)
-        if len(division_ids) not in (1, 2):
-            context.abort(
-                grpc.StatusCode.INVALID_ARGUMENT,
-                "Only 1 or 2 divisions are currently supported",
-            )
-
-        # Reorder teams so that all teams from the same division are contiguous
-        # in the list passed to the solver. The solver expects the first half of
-        # teams to belong to one division and the rest to another.
-        teams_sorted = sorted(list(request.league), key=lambda t: t.division_id)
-
-        num_teams = len(teams_sorted)
-        if num_teams == 0:
-            logger.info("No teams provided in request")
-            return response
-
-        schedule_data = schedule_generator.generate_schedule(13, num_teams)
-
-        if isinstance(schedule_data, str):
-            logger.error("Schedule generation failed: %s", schedule_data)
-            return response
-
-        schedule = {}
-        for week_str, team1_idx, team2_idx in schedule_data[1:]:
-            week = int(week_str)
-            schedule.setdefault(week, []).append((int(team1_idx), int(team2_idx)))
-
-        for week in range(max(schedule.keys()) + 1):
-            weekly = response.matchups.add()
-            for team1_idx, team2_idx in schedule.get(week, []):
-                matchup = weekly.matchups.add()
-                # Map the solver indices back to the correct teams using the
-                # sorted order used when invoking the solver.
-                matchup.team1.CopyFrom(teams_sorted[team1_idx])
-                matchup.team2.CopyFrom(teams_sorted[team2_idx])
-
-        logger.info("Returning schedule response with %d weeks", len(response.matchups))
-
+    teams_sorted = sorted(list(req.league), key=lambda t: t.division_id)
+    num_teams = len(teams_sorted)
+    if num_teams == 0:
+        logger.info("No teams provided in request")
         return response
 
+    schedule_data = schedule_generator.generate_schedule(13, num_teams)
 
-def serve():
+    if isinstance(schedule_data, str):
+        logger.error("Schedule generation failed: %s", schedule_data)
+        return response
+
+    schedule = {}
+    for week_str, team1_idx, team2_idx in schedule_data[1:]:
+        week = int(week_str)
+        schedule.setdefault(week, []).append((int(team1_idx), int(team2_idx)))
+
+    for week in range(max(schedule.keys()) + 1):
+        weekly = response.matchups.add()
+        for team1_idx, team2_idx in schedule.get(week, []):
+            matchup = weekly.matchups.add()
+            matchup.team1.CopyFrom(teams_sorted[team1_idx])
+            matchup.team2.CopyFrom(teams_sorted[team2_idx])
+
+    logger.info("Returning schedule response with %d weeks", len(response.matchups))
+    return response
+
+
+@app.get("/")
+def root() -> tuple[str, int]:
+    return "OK", 200
+
+
+@app.get("/liveness_check")
+@app.get("/_ah/liveness_check")
+@app.get("/readiness_check")
+@app.get("/_ah/readiness_check")
+def health_check() -> tuple[str, int]:
+    return "ok", 200
+
+
+@app.post("/generate-schedule")
+def generate_schedule_http():
+    req_json = request.get_json(force=True)
+    req_pb = json_format.ParseDict(req_json, scheduler_pb2.ScheduleRequest())
+    try:
+        resp_pb = build_schedule_response(req_pb)
+        resp_dict = json_format.MessageToDict(
+            resp_pb, preserving_proto_field_name=True
+        )
+        return jsonify(resp_dict), 200
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+def serve() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
     )
-
-    # Start HTTP health server on port 8080 in a separate thread
-    httpd = HTTPServer(("0.0.0.0", 8080), HealthHandler)
-    threading.Thread(target=httpd.serve_forever, daemon=True).start()
-    logger.info("Health server started on port 8080")
-
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    scheduler_pb2_grpc.add_SchedulerServicer_to_server(SchedulerServicer(), server)
-
-    # Enable reflection
-    SERVICE_NAMES = (
-        scheduler_pb2.DESCRIPTOR.services_by_name["Scheduler"].full_name,
-        reflection.SERVICE_NAME,
-    )
-    reflection.enable_server_reflection(SERVICE_NAMES, server)
-
-    server.add_insecure_port("0.0.0.0:50051")
-    server.start()
-    logger.info("Server started on port 50051 with reflection enabled")
-    server.wait_for_termination()
+    app.run(host="0.0.0.0", port=8080)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -111,12 +111,8 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
             request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
         url = "http://127.0.0.1:8080/generate-schedule"
-        req_dict = json.loads(
-            json.dumps(
-                json_format.MessageToDict(
-                    request, preserving_proto_field_name=True
-                )
-            )
+        req_dict = json_format.MessageToDict(
+            request, preserving_proto_field_name=True
         )
         data = json.dumps(req_dict).encode()
         http_req = urllib.request.Request(
@@ -163,12 +159,8 @@ class TestServerIntegration(unittest.TestCase):
         for i in range(3):
             request.league.append(scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2))
         url = "http://127.0.0.1:8080/generate-schedule"
-        req_dict = json.loads(
-            json.dumps(
-                json_format.MessageToDict(
-                    request, preserving_proto_field_name=True
-                )
-            )
+        req_dict = json_format.MessageToDict(
+            request, preserving_proto_field_name=True
         )
         data = json.dumps(req_dict).encode()
         http_req = urllib.request.Request(

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -111,9 +111,17 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
             request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
         url = "http://127.0.0.1:8080/generate-schedule"
-        req_dict = json.loads(json.dumps(json_format.MessageToDict(request, preserving_proto_field_name=True)))
+        req_dict = json.loads(
+            json.dumps(
+                json_format.MessageToDict(
+                    request, preserving_proto_field_name=True
+                )
+            )
+        )
         data = json.dumps(req_dict).encode()
-        http_req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+        http_req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
         with urllib.request.urlopen(http_req) as resp:
             self.assertEqual(resp.getcode(), 200)
             resp_data = json.load(resp)
@@ -125,7 +133,6 @@ class TestServerIntegration(unittest.TestCase):
         self.assertEqual(len(response.matchups), 13)
         for weekly in response.matchups:
             self.assertEqual(len(weekly.matchups), 5)
-
 
     def test_health_endpoints(self):
         """Verify health and readiness endpoints return 200."""
@@ -156,10 +163,18 @@ class TestServerIntegration(unittest.TestCase):
         for i in range(3):
             request.league.append(scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2))
         url = "http://127.0.0.1:8080/generate-schedule"
-        req_dict = json.loads(json.dumps(json_format.MessageToDict(request, preserving_proto_field_name=True)))
+        req_dict = json.loads(
+            json.dumps(
+                json_format.MessageToDict(
+                    request, preserving_proto_field_name=True
+                )
+            )
+        )
         data = json.dumps(req_dict).encode()
         http_req = urllib.request.Request(
-            url, data=data, headers={"Content-Type": "application/json"}
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
         )
         with self.assertRaises(urllib.error.HTTPError) as cm:
             urllib.request.urlopen(http_req)

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -7,8 +7,10 @@ import logging
 import importlib
 import shutil
 import urllib.request
+import urllib.error
 
-import grpc
+import json
+from google.protobuf import json_format
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DOCKER_IMAGE = "schedule-server:test"
@@ -55,8 +57,6 @@ def _run_container() -> subprocess.Popen:
         "--name",
         CONTAINER_NAME,
         "-p",
-        "50051:50051",
-        "-p",
         "8080:8080",
         "--rm",
         DOCKER_IMAGE,
@@ -77,10 +77,9 @@ class TestServerIntegration(unittest.TestCase):
         # Add the generated protobuf code to the path
         sys.path.append(os.path.join(ROOT_DIR, "src"))
         _build_image()
-        global scheduler_pb2, scheduler_pb2_grpc
+        global scheduler_pb2
         scheduler_pb2 = importlib.import_module("scheduler_pb2")
-        scheduler_pb2_grpc = importlib.import_module("scheduler_pb2_grpc")
-        logging.info("Launching gRPC server container for integration test")
+        logging.info("Launching HTTP server container for integration test")
         cls.proc = _run_container()
         # give the server some time to start
         time.sleep(1)
@@ -88,7 +87,7 @@ class TestServerIntegration(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        logging.info("Stopping gRPC server container")
+        logging.info("Stopping server container")
         subprocess.run(
             ["docker", "stop", CONTAINER_NAME],
             cwd=ROOT_DIR,
@@ -105,17 +104,21 @@ class TestServerIntegration(unittest.TestCase):
 
     def test_generate_schedule_returns_matchups(self):
         logging.info("Sending GenerateSchedule request to server")
-        channel = grpc.insecure_channel("localhost:50051")
-        stub = scheduler_pb2_grpc.SchedulerStub(channel)
-
         request = scheduler_pb2.ScheduleRequest()
         # Create 10 teams split across two divisions but interleaved in the
         # request to ensure the server reorders them correctly.
         for i in range(5):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
             request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
+        url = "http://127.0.0.1:8080/generate-schedule"
+        req_dict = json.loads(json.dumps(json_format.MessageToDict(request, preserving_proto_field_name=True)))
+        data = json.dumps(req_dict).encode()
+        http_req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(http_req) as resp:
+            self.assertEqual(resp.getcode(), 200)
+            resp_data = json.load(resp)
 
-        response = stub.GenerateSchedule(request)
+        response = json_format.ParseDict(resp_data, scheduler_pb2.ScheduleResponse())
         logging.info("Received response with %d weeks", len(response.matchups))
 
         self.assertIsInstance(response, scheduler_pb2.ScheduleResponse)
@@ -123,7 +126,6 @@ class TestServerIntegration(unittest.TestCase):
         for weekly in response.matchups:
             self.assertEqual(len(weekly.matchups), 5)
 
-        channel.close()
 
     def test_health_endpoints(self):
         """Verify health and readiness endpoints return 200."""
@@ -145,9 +147,6 @@ class TestServerIntegration(unittest.TestCase):
     def test_generate_schedule_invalid_divisions(self):
         """Requests with more than two divisions should return an error."""
         logging.info("Sending invalid GenerateSchedule request to server")
-        channel = grpc.insecure_channel("localhost:50051")
-        stub = scheduler_pb2_grpc.SchedulerStub(channel)
-
         request = scheduler_pb2.ScheduleRequest()
         # Create teams across three divisions to trigger the validation.
         for i in range(4):
@@ -156,12 +155,18 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
         for i in range(3):
             request.league.append(scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2))
+        url = "http://127.0.0.1:8080/generate-schedule"
+        req_dict = json.loads(json.dumps(json_format.MessageToDict(request, preserving_proto_field_name=True)))
+        data = json.dumps(req_dict).encode()
+        http_req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            urllib.request.urlopen(http_req)
 
-        with self.assertRaises(grpc.RpcError) as cm:
-            stub.GenerateSchedule(request)
-        self.assertEqual(cm.exception.code(), grpc.StatusCode.INVALID_ARGUMENT)
-
-        channel.close()
+        self.assertEqual(cm.exception.code, 400)
+        body = json.loads(cm.exception.read().decode())
+        self.assertIn("error", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor server to Flask-based HTTP API
- update integration tests for HTTP requests
- provide HTTP example script
- update Dockerfile, requirements, and README for the new server

## Testing
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687ea1575180832e9c6ebd827e6fa3eb