### PR TITLE
Update example scripts to use hosted API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for i in range(10):
 req_dict = json_format.MessageToDict(request, preserving_proto_field_name=True)
 data = json.dumps(req_dict).encode()
 http_req = urllib.request.Request(
-    'http://localhost:8080/generate-schedule',
+    'https://ff-scheduler-466320.uw.r.appspot.com/generate-schedule',
     data=data,
     headers={'Content-Type': 'application/json'}
 )
@@ -73,11 +73,11 @@ Ensure the protobuf files are built (`nox -s build`) so that `scheduler_pb2` is
 available before running the snippet.
 
 You can also run the example script in `examples/example_request.py` to see the
-same request in action. Pass the server IP if it is not running locally:
+same request in action against the hosted API:
 
 ```bash
 nox -s build
-PYTHONPATH=.:src python examples/example_request.py 192.168.1.50
+PYTHONPATH=.:src python examples/example_request.py
 ```
 
 ## Docker

--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -15,10 +15,10 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     return request
 
 
-def main(host: str = "localhost") -> None:
+def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
     """Send an example schedule request to the HTTP server."""
 
-    url = f"http://{host}:8080/generate-schedule"
+    url = url.rstrip("/") + "/generate-schedule"
     request = build_request(10)
     req_dict = json_format.MessageToDict(
         request, preserving_proto_field_name=True
@@ -39,12 +39,14 @@ def main(host: str = "localhost") -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Send an example ScheduleRequest")
+    parser = argparse.ArgumentParser(
+        description="Send an example ScheduleRequest over HTTP"
+    )
     parser.add_argument(
-        "host",
+        "url",
         nargs="?",
-        default="localhost",
-        help="IP or hostname of the running HTTP server (default: localhost)",
+        default="https://ff-scheduler-466320.uw.r.appspot.com",
+        help="Base URL of the schedule service",
     )
     args = parser.parse_args()
-    main(args.host)
+    main(args.url)

--- a/examples/example_request_https.py
+++ b/examples/example_request_https.py
@@ -1,8 +1,8 @@
 import argparse
-import urllib.parse
-import grpc
+import json
+import urllib.request
+from google.protobuf import json_format
 from src import scheduler_pb2
-from src import scheduler_pb2_grpc
 
 
 def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
@@ -17,16 +17,17 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     return request
 
 
-def main(url: str) -> None:
+def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
     """Send an example schedule request to a deployed server via HTTPS."""
-    parsed = urllib.parse.urlparse(url)
-    host = parsed.netloc or parsed.path
-    target = f"{host}:443"
-    channel = grpc.secure_channel(target, grpc.ssl_channel_credentials())
-    stub = scheduler_pb2_grpc.SchedulerStub(channel)
-
+    url = url.rstrip("/") + "/generate-schedule"
     request = build_request(10)
-    response = stub.GenerateSchedule(request)
+    req_dict = json_format.MessageToDict(request, preserving_proto_field_name=True)
+    data = json.dumps(req_dict).encode()
+    http_req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(http_req) as resp:
+        resp_data = json.load(resp)
+
+    response = json_format.ParseDict(resp_data, scheduler_pb2.ScheduleResponse())
 
     for week_idx, weekly in enumerate(response.matchups, start=1):
         print(f"Week {week_idx}")
@@ -35,12 +36,14 @@ def main(url: str) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Send an example ScheduleRequest over HTTPS")
+    parser = argparse.ArgumentParser(
+        description="Send an example ScheduleRequest to the HTTPS service"
+    )
     parser.add_argument(
         "url",
         nargs="?",
         default="https://ff-scheduler-466320.uw.r.appspot.com",
-        help="Full HTTPS URL of the deployed API",
+        help="Base URL of the schedule service",
     )
     args = parser.parse_args()
     main(args.url)


### PR DESCRIPTION
## Summary
- update example request scripts to hit the deployed app engine
- call the new scripts in the README docs

## Testing
- `nox -s lint`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687eab4073a0832ea47244c2e09e22a9