### PR TITLE
Add deployment smoke test workflow

### DIFF
--- a/.github/workflows/example-request.yml
+++ b/.github/workflows/example-request.yml
@@ -1,11 +1,18 @@
-name: Example Request
+name: Deployment Smoke Test
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_run:
+    workflows: ["Deploy App Engine"]
+    types:
+      - completed
 
 jobs:
   run-example:
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ docker run -p 8080:8080 schedule-server
 
 The image compiles the protobuf definitions during build and starts the HTTP server on port `8080`.
 The `compile_protos.py` script is copied into the image so that any new `.proto` files will be included automatically.
+
+## Deployment Smoke Test
+
+A GitHub Actions workflow runs `examples/example_request_https.py` after each deployment and once a day to verify that the production server responds correctly. The script sends a simple schedule request and checks that the response contains 13 weeks with five matchups per week.

--- a/examples/example_request_https.py
+++ b/examples/example_request_https.py
@@ -1,7 +1,10 @@
 import argparse
 import json
+import sys
 import urllib.request
+
 from google.protobuf import json_format
+
 from src import scheduler_pb2
 
 
@@ -18,21 +21,38 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
 
 
 def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
-    """Send an example schedule request to a deployed server via HTTPS."""
+    """Send a request to the deployed server and verify the response."""
+
     url = url.rstrip("/") + "/generate-schedule"
+
     request = build_request(10)
-    req_dict = json_format.MessageToDict(request, preserving_proto_field_name=True)
+    req_dict = json_format.MessageToDict(
+        request, preserving_proto_field_name=True
+    )
     data = json.dumps(req_dict).encode()
-    http_req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    http_req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+
     with urllib.request.urlopen(http_req) as resp:
+        if resp.getcode() != 200:
+            raise AssertionError(f"Unexpected status code {resp.getcode()}")
         resp_data = json.load(resp)
 
     response = json_format.ParseDict(resp_data, scheduler_pb2.ScheduleResponse())
 
-    for week_idx, weekly in enumerate(response.matchups, start=1):
-        print(f"Week {week_idx}")
-        for matchup in weekly.matchups:
-            print(f"  {matchup.team1.name} vs {matchup.team2.name}")
+    if len(response.matchups) != 13:
+        raise AssertionError(
+            f"Expected 13 weeks of matchups, got {len(response.matchups)}"
+        )
+    for weekly in response.matchups:
+        if len(weekly.matchups) != 5:
+            raise AssertionError(
+                "Each week should contain 5 matchups, "
+                f"got {len(weekly.matchups)}"
+            )
+
+    print("Server returned expected schedule")
 
 
 if __name__ == "__main__":
@@ -46,4 +66,8 @@ if __name__ == "__main__":
         help="Base URL of the schedule service",
     )
     args = parser.parse_args()
-    main(args.url)
+    try:
+        main(args.url)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Test failed: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- convert `examples/example_request_https.py` into a verification script
- run the example request as a smoke test once a day and after deployments
- rename workflow to Deployment Smoke Test and document its purpose

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687eb22409b0832ea9a07a2cf6bebdf6