### PR TITLE
Configure health check intervals

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -9,5 +9,7 @@ env_variables:
   PYTHONPATH: "/app"
 liveness_check:
   path: "/liveness_check"
+  check_interval_sec: 300
 readiness_check:
   path: "/readiness_check"
+  check_interval_sec: 300


### PR DESCRIPTION
## Summary
- configure liveness and readiness checks with the maximum allowed interval

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687ed975c044832ea20ef580e9a721ae