### PR TITLE
Improve logging and return errors for infeasible schedules

### DIFF
--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import urllib.request
+import urllib.error
 from google.protobuf import json_format
 from src import scheduler_pb2
 
@@ -15,11 +16,11 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     return request
 
 
-def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
-    """Send an example schedule request to the HTTP server."""
+def request_and_print(url: str, num_teams: int) -> None:
+    """Request a schedule for ``num_teams`` and print it."""
 
     url = url.rstrip("/") + "/generate-schedule"
-    request = build_request(10)
+    request = build_request(num_teams)
     req_dict = json_format.MessageToDict(
         request, preserving_proto_field_name=True
     )
@@ -32,10 +33,23 @@ def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
 
     response = json_format.ParseDict(resp_data, scheduler_pb2.ScheduleResponse())
 
+    print(f"Schedule for {num_teams} teams")
     for week_idx, weekly in enumerate(response.matchups, start=1):
         print(f"Week {week_idx}")
         for matchup in weekly.matchups:
             print(f"  {matchup.team1.name} vs {matchup.team2.name}")
+    print()
+
+
+def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com", teams: str = "10,8,12") -> None:
+    """Send example schedule requests to the HTTP server."""
+
+    for teams in [int(t) for t in teams.split(",")]:
+        try:
+            request_and_print(url, teams)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode()
+            print(f"Request for {teams} teams failed: {body}")
 
 
 if __name__ == "__main__":
@@ -48,5 +62,10 @@ if __name__ == "__main__":
         default="https://ff-scheduler-466320.uw.r.appspot.com",
         help="Base URL of the schedule service",
     )
+    parser.add_argument(
+        "--teams",
+        default="10,8,12",
+        help="Comma separated list of team counts to request",
+    )
     args = parser.parse_args()
-    main(args.url)
+    main(args.url, args.teams)

--- a/examples/example_request_https.py
+++ b/examples/example_request_https.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import sys
 import urllib.request
+import urllib.error
 
 from google.protobuf import json_format
 
@@ -20,12 +21,12 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     return request
 
 
-def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
-    """Send a request to the deployed server and verify the response."""
+def request_and_check(url: str, num_teams: int) -> None:
+    """Request a schedule and perform basic sanity checks."""
 
     url = url.rstrip("/") + "/generate-schedule"
 
-    request = build_request(10)
+    request = build_request(num_teams)
     req_dict = json_format.MessageToDict(
         request, preserving_proto_field_name=True
     )
@@ -46,13 +47,24 @@ def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com") -> None:
             f"Expected 13 weeks of matchups, got {len(response.matchups)}"
         )
     for weekly in response.matchups:
-        if len(weekly.matchups) != 5:
+        if len(weekly.matchups) != num_teams // 2:
             raise AssertionError(
-                "Each week should contain 5 matchups, "
+                "Each week should contain the expected number of matchups, "
                 f"got {len(weekly.matchups)}"
             )
 
-    print("Server returned expected schedule")
+    print(f"Server returned schedule for {num_teams} teams")
+
+
+def main(url: str = "https://ff-scheduler-466320.uw.r.appspot.com", teams: str = "10") -> None:
+    """Send requests to the deployed server and verify the responses."""
+
+    for num in [int(t) for t in teams.split(",")]:
+        try:
+            request_and_check(url, num)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode()
+            print(f"Request for {num} teams failed: {body}")
 
 
 if __name__ == "__main__":
@@ -65,9 +77,14 @@ if __name__ == "__main__":
         default="https://ff-scheduler-466320.uw.r.appspot.com",
         help="Base URL of the schedule service",
     )
+    parser.add_argument(
+        "--teams",
+        default="10",
+        help="Comma separated list of team counts to request",
+    )
     args = parser.parse_args()
     try:
-        main(args.url)
+        main(args.url, args.teams)
     except Exception as exc:  # pylint: disable=broad-except
         print(f"Test failed: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -1,4 +1,7 @@
+import logging
 from ortools.linear_solver import pywraplp
+
+logger = logging.getLogger(__name__)
 
 
 # Returns all of the variables in variables that correspond to the
@@ -39,12 +42,14 @@ def _get_schedule_data(variables, weeks_param, teams_param):
 
 
 def generate_schedule(num_weeks, num_teams):
+    logger.info("Generating schedule: %d weeks, %d teams", num_weeks, num_teams)
     weeks = range(num_weeks)
     teams = range(num_teams)
 
     # Create the mip solver with the SCIP backend.
     solver = pywraplp.Solver.CreateSolver("SAT")
     if not solver:
+        logger.error("Solver could not be created")
         return "Error: Solver could not be created."
 
     infinity = solver.infinity()
@@ -135,11 +140,14 @@ def generate_schedule(num_weeks, num_teams):
     objective.SetMaximization()
 
     status = solver.Solve()
+    logger.info("Solver finished with status %s", status)
 
     if status == pywraplp.Solver.OPTIMAL:
         schedule_data = _get_schedule_data(variables, weeks, teams)
+        logger.info("Generated schedule with %d matchups", len(schedule_data) - 1)
         return schedule_data
     else:
+        logger.error("The problem does not have an optimal solution.")
         return "The problem does not have an optimal solution."
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -13,7 +13,11 @@ app = Flask(__name__)
 def build_schedule_response(
     req: scheduler_pb2.ScheduleRequest,
 ) -> scheduler_pb2.ScheduleResponse:
-    logger.info("GenerateSchedule request received with %d teams", len(req.league))
+    logger.info(
+        "GenerateSchedule request received with %d teams across %d divisions",
+        len(req.league),
+        len({t.division_id for t in req.league} | {d.id for d in req.divisions}),
+    )
 
     response = scheduler_pb2.ScheduleResponse()
 
@@ -32,7 +36,7 @@ def build_schedule_response(
 
     if isinstance(schedule_data, str):
         logger.error("Schedule generation failed: %s", schedule_data)
-        return response
+        raise ValueError(schedule_data)
 
     schedule = {}
     for week_str, team1_idx, team2_idx in schedule_data[1:]:
@@ -66,12 +70,14 @@ def health_check() -> tuple[str, int]:
 @app.post("/generate-schedule")
 def generate_schedule_http():
     req_json = request.get_json(force=True)
+    logger.debug("/generate-schedule body: %s", req_json)
     req_pb = json_format.ParseDict(req_json, scheduler_pb2.ScheduleRequest())
     try:
         resp_pb = build_schedule_response(req_pb)
         resp_dict = json_format.MessageToDict(
             resp_pb, preserving_proto_field_name=True
         )
+        logger.debug("Returning response with %d weeks", len(resp_pb.matchups))
         return jsonify(resp_dict), 200
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -175,6 +175,30 @@ class TestServerIntegration(unittest.TestCase):
         body = json.loads(cm.exception.read().decode())
         self.assertIn("error", body)
 
+    def test_generate_schedule_infeasible(self):
+        """Verify the server returns an error when the schedule cannot be generated."""
+        logging.info("Sending infeasible GenerateSchedule request to server")
+        request = scheduler_pb2.ScheduleRequest()
+        for i in range(4):
+            request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
+            request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
+        url = "http://127.0.0.1:8080/generate-schedule"
+        req_dict = json_format.MessageToDict(
+            request, preserving_proto_field_name=True
+        )
+        data = json.dumps(req_dict).encode()
+        http_req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            urllib.request.urlopen(http_req)
+
+        self.assertEqual(cm.exception.code, 400)
+        body = json.loads(cm.exception.read().decode())
+        self.assertIn("error", body)
+
 
 if __name__ == "__main__":
     logging.basicConfig(


### PR DESCRIPTION
## Summary
- add debug logging for server endpoints
- raise errors when schedule generation fails
- improve schedule generator logs
- add example requests for 8 and 12 team leagues
- test that server returns 400 when schedule cannot be generated

## Testing
- `nox -s lint`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687edcdec9c0832eb682bb38125314c0