### PR TITLE
Enable CORS for schedule server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The server listens on port `8080` and exposes health endpoints used by GCP App E
 
 Both endpoints return `200 OK` with the body `"ok"`.
 
+Cross-Origin Resource Sharing (CORS) is enabled so browser-based clients can
+request schedules from any domain.
+
 ## Example Request
 
 After starting the server, you can send an HTTP request to it using Python. The

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Both endpoints return `200 OK` with the body `"ok"`.
 
 Cross-Origin Resource Sharing (CORS) is enabled so browser-based clients can
 request schedules from trusted domains. Requests originating from `*.vercel.app`
-or any domain containing `google` or `gcp` are allowed.
+(including any paths under those subdomains) or any domain containing `google`
+or `gcp` are allowed.
 
 ## Example Request
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The server listens on port `8080` and exposes health endpoints used by GCP App E
 Both endpoints return `200 OK` with the body `"ok"`.
 
 Cross-Origin Resource Sharing (CORS) is enabled so browser-based clients can
-request schedules from any domain.
+request schedules from trusted domains. Requests originating from `*.vercel.app`
+or any domain containing `google` or `gcp` are allowed.
 
 ## Example Request
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ grpcio-reflection==1.73.1
 Flask==3.0.3
 flake8==7.0.0
 black==24.4.2
+flask-cors==6.0.1

--- a/src/server.py
+++ b/src/server.py
@@ -1,6 +1,7 @@
 import logging
 
 from flask import Flask, jsonify, request
+from flask_cors import CORS
 from google.protobuf import json_format
 
 import src.scheduler_pb2 as scheduler_pb2
@@ -8,6 +9,7 @@ from src import schedule_generator
 
 logger = logging.getLogger(__name__)
 app = Flask(__name__)
+CORS(app)
 
 
 def build_schedule_response(

--- a/src/server.py
+++ b/src/server.py
@@ -9,7 +9,13 @@ from src import schedule_generator
 
 logger = logging.getLogger(__name__)
 app = Flask(__name__)
-CORS(app)
+# Allow cross-origin requests only from trusted domains.
+TRUSTED_ORIGINS = [
+    r".*\.vercel\.app$",
+    r".*google.*",
+    r".*gcp.*",
+]
+CORS(app, origins=TRUSTED_ORIGINS)
 
 
 def build_schedule_response(

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 # Allow cross-origin requests only from trusted domains.
 TRUSTED_ORIGINS = [
-    r".*\.vercel\.app$",
+    # Allow all subdomains of vercel.app and any paths beneath them.
+    r".*\.vercel\.app.*",
     r".*google.*",
     r".*gcp.*",
 ]


### PR DESCRIPTION
## Summary
- allow cross-origin requests in the server
- document CORS in README
- add `flask-cors` dependency

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687ee4dda4a8832e88c3965f63d7b2af