### PR TITLE
Add optional division constraints

### DIFF
--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -13,6 +13,8 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
     for i in range(num_teams // 2):
         request.league.append(scheduler_pb2.Team(name=f"Division 0 Team {i+1}", division_id=0))
         request.league.append(scheduler_pb2.Team(name=f"Division 1 Team {i+1}", division_id=1))
+    request.in_division_play_twice = True
+    request.out_of_division_play_once = True
     return request
 
 

--- a/examples/example_request_https.py
+++ b/examples/example_request_https.py
@@ -18,6 +18,8 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
         request.league.append(
             scheduler_pb2.Team(name=f"Division 1 Team {i+1}", division_id=1)
         )
+    request.in_division_play_twice = True
+    request.out_of_division_play_once = True
     return request
 
 

--- a/src/protos/scheduler.proto
+++ b/src/protos/scheduler.proto
@@ -8,6 +8,8 @@ service Scheduler {
 message ScheduleRequest {
     repeated Team league = 1;
     repeated Division divisions = 2;
+    bool in_division_play_twice = 3;
+    bool out_of_division_play_once = 4;
 }
 
 message Team {

--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -41,8 +41,15 @@ def _get_schedule_data(variables, weeks_param, teams_param):
     return schedule_data
 
 
-def generate_schedule(num_weeks, num_teams):
-    logger.info("Generating schedule: %d weeks, %d teams", num_weeks, num_teams)
+def generate_schedule(
+    num_weeks,
+    num_teams,
+    in_division_play_twice=False,
+    out_of_division_play_once=False,
+):
+    logger.info(
+        "Generating schedule: %d weeks, %d teams", num_weeks, num_teams
+    )
     weeks = range(num_weeks)
     teams = range(num_teams)
 
@@ -89,31 +96,37 @@ def generate_schedule(num_weeks, num_teams):
                     constraint.SetCoefficient(variables[team][team2][week], 1)
                     constraint.SetCoefficient(variables[team2][team][week], -1)
 
-    # Teams within the division play each other twice
-    # for each team combination in each division, for all weeks
-    #  sum( x[i][j][w] ) = 4
-    for team in teams:
-        for team2 in teams:
-            if (team != team2) and (
-                (team < num_teams / 2 and team2 < num_teams / 2)
-                or (team >= num_teams / 2 and team2 >= num_teams / 2)
-            ):
-                constraint = solver.RowConstraint(4, 4, "")
-                for variable in getTeamsVariablesForAllWeeks(variables, team, team2, weeks, teams):
-                    constraint.SetCoefficient(variable, 1)
+    if in_division_play_twice:
+        # Teams within the division play each other twice
+        # for each team combination in each division, for all weeks
+        #  sum( x[i][j][w] ) = 4
+        for team in teams:
+            for team2 in teams:
+                if (team != team2) and (
+                    (team < num_teams / 2 and team2 < num_teams / 2)
+                    or (team >= num_teams / 2 and team2 >= num_teams / 2)
+                ):
+                    constraint = solver.RowConstraint(4, 4, "")
+                    for variable in getTeamsVariablesForAllWeeks(
+                        variables, team, team2, weeks, teams
+                    ):
+                        constraint.SetCoefficient(variable, 1)
 
-    # Teams play out of division opponents once
-    # for each team combination outside each division, for all weeks
-    #  sum( x[i][j][w] ) = 2
-    for team in teams:
-        for team2 in teams:
-            if (team != team2) and not (
-                (team < num_teams / 2 and team2 < num_teams / 2)
-                or (team >= num_teams / 2 and team2 >= num_teams / 2)
-            ):
-                constraint = solver.RowConstraint(2, 2, "")
-                for variable in getTeamsVariablesForAllWeeks(variables, team, team2, weeks, teams):
-                    constraint.SetCoefficient(variable, 1)
+    if out_of_division_play_once:
+        # Teams play out of division opponents once
+        # for each team combination outside each division, for all weeks
+        #  sum( x[i][j][w] ) = 2
+        for team in teams:
+            for team2 in teams:
+                if (team != team2) and not (
+                    (team < num_teams / 2 and team2 < num_teams / 2)
+                    or (team >= num_teams / 2 and team2 >= num_teams / 2)
+                ):
+                    constraint = solver.RowConstraint(2, 2, "")
+                    for variable in getTeamsVariablesForAllWeeks(
+                        variables, team, team2, weeks, teams
+                    ):
+                        constraint.SetCoefficient(variable, 1)
 
     # Teams do not play the same matchup in the same 4 week span
     for team in teams:

--- a/src/server.py
+++ b/src/server.py
@@ -41,7 +41,12 @@ def build_schedule_response(
         logger.info("No teams provided in request")
         return response
 
-    schedule_data = schedule_generator.generate_schedule(13, num_teams)
+    schedule_data = schedule_generator.generate_schedule(
+        13,
+        num_teams,
+        req.in_division_play_twice,
+        req.out_of_division_play_once,
+    )
 
     if isinstance(schedule_data, str):
         logger.error("Schedule generation failed: %s", schedule_data)

--- a/tests/test_integration_schedule_generator.py
+++ b/tests/test_integration_schedule_generator.py
@@ -20,7 +20,12 @@ class TestScheduleGeneratorIntegration(unittest.TestCase):
             cls.num_teams,
         )
 
-        cls.schedule_data = schedule_generator.generate_schedule(cls.num_weeks, cls.num_teams)
+        cls.schedule_data = schedule_generator.generate_schedule(
+            cls.num_weeks,
+            cls.num_teams,
+            True,
+            True,
+        )
 
         logging.info("generate_schedule returned %d rows", len(cls.schedule_data))
 

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -123,6 +123,8 @@ class TestServerIntegration(unittest.TestCase):
         for i in range(5):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
             request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
+        request.in_division_play_twice = True
+        request.out_of_division_play_once = True
         url = "http://127.0.0.1:8080/generate-schedule"
         req_dict = json_format.MessageToDict(
             request, preserving_proto_field_name=True
@@ -171,6 +173,8 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
         for i in range(3):
             request.league.append(scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2))
+        request.in_division_play_twice = True
+        request.out_of_division_play_once = True
         url = "http://127.0.0.1:8080/generate-schedule"
         req_dict = json_format.MessageToDict(
             request, preserving_proto_field_name=True
@@ -195,6 +199,8 @@ class TestServerIntegration(unittest.TestCase):
         for i in range(4):
             request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
+        request.in_division_play_twice = True
+        request.out_of_division_play_once = True
         url = "http://127.0.0.1:8080/generate-schedule"
         req_dict = json_format.MessageToDict(
             request, preserving_proto_field_name=True

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -122,7 +122,9 @@ class TestScheduleGenerator(unittest.TestCase):
                 [1, 0, 1],
                 [1, 1, 0],
             ]
-            result = schedule_generator.generate_schedule(2, 2)
+            result = schedule_generator.generate_schedule(
+                2, 2, True, True
+            )
 
         expected = [["Week", "Team1", "Team2"], [0, 0, 1], [0, 1, 0], [1, 0, 1], [1, 1, 0]]
         self.assertEqual(result, expected)
@@ -135,14 +137,14 @@ class TestScheduleGenerator(unittest.TestCase):
         # Mock solver behavior for no optimal solution
         mock_solver_instance.Solve.return_value = schedule_generator.pywraplp.Solver.INFEASIBLE
 
-        result = schedule_generator.generate_schedule(2, 2)
+        result = schedule_generator.generate_schedule(2, 2, True, True)
         self.assertEqual(result, "The problem does not have an optimal solution.")
 
     @patch("src.schedule_generator.pywraplp.Solver")
     def test_generate_schedule_solver_creation_failure(self, MockSolver):
         MockSolver.CreateSolver.return_value = None
 
-        result = schedule_generator.generate_schedule(2, 2)
+        result = schedule_generator.generate_schedule(2, 2, True, True)
         self.assertEqual(result, "Error: Solver could not be created.")
 
 


### PR DESCRIPTION
## Summary
- add division constraint flags to the protobuf request
- apply optional constraints in the solver
- read the flags in server
- update examples and integration tests

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687efffd1748832eb0e5863ad93005a7