### PR TITLE
Bump npm proto types version to 0.2.0

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ff-schedule-protos",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ff-schedule-protos",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "protobufjs": "^7.2.4",
         "protobufjs-cli": "^1.1.3"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ff-schedule-protos",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "TypeScript protobuf definitions for Fantasy Football Schedule Generator",
   "main": "dist/scheduler.js",
   "types": "dist/scheduler.d.ts",


### PR DESCRIPTION
## Summary
- update the npm proto package version to 0.2.0 in `package.json`
- update the lockfile to match

## Testing
- `nox -s tests`
- `nox -s lint`


------
https://chatgpt.com/codex/tasks/task_e_687f1ec4d1fc832e8c15c503cebe354e