### PR TITLE
Rename team variable functions

### DIFF
--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -4,28 +4,41 @@ from ortools.linear_solver import pywraplp
 logger = logging.getLogger(__name__)
 
 
-# Returns all of the variables in variables that correspond to the
-# given team playing in a game in the given week
-# Excludes variables representing the team playing itself
-def getTeamsVariablesForWeek(variables, team, week, weeks_param, teams_param):
-    teamsVariables = []
+# Returns all of the variables in ``variables`` that correspond to the given
+# team playing in a game during the specified week. Variables representing the
+# team playing itself are excluded.
+def get_team_variables_for_week(variables, team, week, weeks_param, teams_param):
+    teams_variables = []
     for w in weeks_param:
         for i in teams_param:
             for j in teams_param:
                 if ((i == team) or (j == team)) and (i != j) and (w == week):
-                    teamsVariables.append(variables[i][j][w])
-    return teamsVariables
+                    teams_variables.append(variables[i][j][w])
+    return teams_variables
 
 
-# Returns all of the variables in variables that represent team 1 playing in team 2 in any week
-def getTeamsVariablesForAllWeeks(variables, team1, team2, weeks_param, teams_param):
-    teamsVariables = []
+# Backwards compatibility
+getTeamsVariablesForWeek = get_team_variables_for_week
+
+
+# Returns all of the variables in ``variables`` that represent ``team1`` playing
+# ``team2`` in any week.
+def get_team_variables_for_all_weeks(
+    variables, team1, team2, weeks_param, teams_param
+):
+    teams_variables = []
     for w in weeks_param:
         for i in teams_param:
             for j in teams_param:
-                if ((i == team1) and (j == team2)) or ((i == team2) and (j == team1)):
-                    teamsVariables.append(variables[i][j][w])
-    return teamsVariables
+                if ((i == team1) and (j == team2)) or (
+                    (i == team2) and (j == team1)
+                ):
+                    teams_variables.append(variables[i][j][w])
+    return teams_variables
+
+
+# Backwards compatibility
+getTeamsVariablesForAllWeeks = get_team_variables_for_all_weeks
 
 
 def _get_schedule_data(variables, weeks_param, teams_param):
@@ -90,7 +103,9 @@ def generate_schedule(
     for week in weeks:
         for team in teams:
             constraint = solver.RowConstraint(2, 2, "")
-            for variable in getTeamsVariablesForWeek(variables, team, week, weeks, teams):
+            for variable in get_team_variables_for_week(
+                variables, team, week, weeks, teams
+            ):
                 constraint.SetCoefficient(variable, 1)
 
     # when team 1 plays team 2 in a given week, ensure team 2 plays team 1
@@ -114,7 +129,7 @@ def generate_schedule(
                     or (team >= num_teams / 2 and team2 >= num_teams / 2)
                 ):
                     constraint = solver.RowConstraint(4, 4, "")
-                    for variable in getTeamsVariablesForAllWeeks(
+                    for variable in get_team_variables_for_all_weeks(
                         variables, team, team2, weeks, teams
                     ):
                         constraint.SetCoefficient(variable, 1)
@@ -130,7 +145,7 @@ def generate_schedule(
                     or (team >= num_teams / 2 and team2 >= num_teams / 2)
                 ):
                     constraint = solver.RowConstraint(2, 2, "")
-                    for variable in getTeamsVariablesForAllWeeks(
+                    for variable in get_team_variables_for_all_weeks(
                         variables, team, team2, weeks, teams
                     ):
                         constraint.SetCoefficient(variable, 1)

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -15,9 +15,9 @@ class TestScheduleGenerator(unittest.TestCase):
             [[f"var_{i}_{j}_{w}" for w in self.weeks] for j in self.teams] for i in self.teams
         ]
 
-    def test_getTeamsVariablesForWeek(self):
+    def test_get_team_variables_for_week(self):
         # Test for team 3, week 5
-        result = schedule_generator.getTeamsVariablesForWeek(
+        result = schedule_generator.get_team_variables_for_week(
             self.mock_variables, 3, 5, self.weeks, self.teams
         )
 
@@ -30,20 +30,20 @@ class TestScheduleGenerator(unittest.TestCase):
         self.assertCountEqual(result, expected_vars)
 
         # Test with a team that doesn't exist
-        result_invalid_team = schedule_generator.getTeamsVariablesForWeek(
+        result_invalid_team = schedule_generator.get_team_variables_for_week(
             self.mock_variables, 99, 5, self.weeks, self.teams
         )
         self.assertEqual(result_invalid_team, [])
 
         # Test with a week that doesn't exist
-        result_invalid_week = schedule_generator.getTeamsVariablesForWeek(
+        result_invalid_week = schedule_generator.get_team_variables_for_week(
             self.mock_variables, 3, 99, self.weeks, self.teams
         )
         self.assertEqual(result_invalid_week, [])
 
-    def test_getTeamsVariablesForAllWeeks(self):
+    def test_get_team_variables_for_all_weeks(self):
         # Test for team 1 vs team 8
-        result = schedule_generator.getTeamsVariablesForAllWeeks(
+        result = schedule_generator.get_team_variables_for_all_weeks(
             self.mock_variables, 1, 8, self.weeks, self.teams
         )
 
@@ -55,7 +55,7 @@ class TestScheduleGenerator(unittest.TestCase):
         self.assertCountEqual(result, expected_vars)
 
         # Test with teams that don't exist
-        result_invalid_teams = schedule_generator.getTeamsVariablesForAllWeeks(
+        result_invalid_teams = schedule_generator.get_team_variables_for_all_weeks(
             self.mock_variables, 99, 100, self.weeks, self.teams
         )
         self.assertEqual(result_invalid_teams, [])


### PR DESCRIPTION
## Summary
- rename `getTeamsVariablesForWeek` -> `get_team_variables_for_week`
- rename `getTeamsVariablesForAllWeeks` -> `get_team_variables_for_all_weeks`
- update references and tests
- keep aliases for backwards compatibility

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687fafbcf7a8832e91b3b6ccd94ff0ea