### PR TITLE
Add gcloudignore file for deployment

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,19 @@
+# Ignore git and build artifacts
+.git
+.gitignore
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.dylib
+*.egg-info/
+*.pytest_cache/
+.nox/
+.venv/
+venv/
+*.csv
+schedule.csv
+examples/
+tests/
+Dockerfile


### PR DESCRIPTION
## Summary
- add `.gcloudignore` at repo root based on `.dockerignore`
- ensures gcloud deployments skip build/test artifacts

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687fb66c7f5c832ebee7fa996efb2323