### PR TITLE
Encapsulate proto compilation in main()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ file found in that directory.
 nox -s build
 ```
 
-This will create the generated `_pb2.py` files next to your source code. You can also run `python compile_protos.py` directly if you prefer not to use Nox.
+This will create the generated `_pb2.py` files next to your source code. You can
+also run `python compile_protos.py` directly if you prefer not to use Nox. The
+script exposes a `main()` function, so it can be imported and called from other
+Python code as `compile_protos.main()`.
 
 ## Running the Server
 

--- a/compile_protos.py
+++ b/compile_protos.py
@@ -1,19 +1,27 @@
 from pathlib import Path
 from grpc_tools import protoc
 
-PROTO_DIR = Path("src/protos")
-OUT_DIR = Path("src")
 
-proto_files = [str(p) for p in PROTO_DIR.glob("*.proto")]
+def main() -> None:
+    """Compile all protobuf definitions in ``src/protos``."""
 
-if not proto_files:
-    raise SystemExit("No .proto files found")
+    PROTO_DIR = Path("src/protos")
+    OUT_DIR = Path("src")
 
-protoc_args = [
-    "grpc_tools.protoc",
-    f"-I{PROTO_DIR}",
-    f"--python_out={OUT_DIR}",
-    f"--grpc_python_out={OUT_DIR}",
-] + proto_files
+    proto_files = [str(p) for p in PROTO_DIR.glob("*.proto")]
 
-protoc.main(protoc_args)
+    if not proto_files:
+        raise SystemExit("No .proto files found")
+
+    protoc_args = [
+        "grpc_tools.protoc",
+        f"-I{PROTO_DIR}",
+        f"--python_out={OUT_DIR}",
+        f"--grpc_python_out={OUT_DIR}",
+    ] + proto_files
+
+    protoc.main(protoc_args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wrap compile_protos.py logic in a `main` function
- call `main()` under `if __name__ == '__main__'`
- document how `compile_protos.main()` can be imported and called

## Testing
- `nox -s tests`
- `nox -s lint`


------
https://chatgpt.com/codex/tasks/task_e_687fb6801968832e8fa8576cd2fe9ff7