### PR TITLE
Add num_weeks option to ScheduleRequest

### DIFF
--- a/examples/example_request.py
+++ b/examples/example_request.py
@@ -15,6 +15,7 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
         request.league.append(scheduler_pb2.Team(name=f"Division 1 Team {i+1}", division_id=1))
     request.options.in_division_play_twice = True
     request.options.out_of_division_play_once = True
+    request.options.num_weeks = 13
     return request
 
 

--- a/examples/example_request_https.py
+++ b/examples/example_request_https.py
@@ -20,6 +20,7 @@ def build_request(num_teams: int) -> scheduler_pb2.ScheduleRequest:
         )
     request.options.in_division_play_twice = True
     request.options.out_of_division_play_once = True
+    request.options.num_weeks = 13
     return request
 
 

--- a/src/protos/scheduler.proto
+++ b/src/protos/scheduler.proto
@@ -14,6 +14,7 @@ message ScheduleRequest {
 message Options {
     bool in_division_play_twice = 1;
     bool out_of_division_play_once = 2;
+    int32 num_weeks = 3;
 }
 
 message Team {

--- a/src/server.py
+++ b/src/server.py
@@ -25,12 +25,13 @@ def build_schedule_response(
     logger.info(
         (
             "GenerateSchedule request received with %d teams across %d divisions "
-            "(in_division_play_twice=%s, out_of_division_play_once=%s)"
+            "(in_division_play_twice=%s, out_of_division_play_once=%s, num_weeks=%d)"
         ),
         len(req.league),
         len({t.division_id for t in req.league} | {d.id for d in req.divisions}),
         req.options.in_division_play_twice,
         req.options.out_of_division_play_once,
+        req.options.num_weeks if req.options.num_weeks else 13,
     )
 
     response = scheduler_pb2.ScheduleResponse()
@@ -46,8 +47,10 @@ def build_schedule_response(
         logger.info("No teams provided in request")
         return response
 
+    num_weeks = req.options.num_weeks or 13
+
     schedule_data = schedule_generator.generate_schedule(
-        13,
+        num_weeks,
         num_teams,
         req.options.in_division_play_twice,
         req.options.out_of_division_play_once,

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -125,6 +125,7 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
         request.options.in_division_play_twice = True
         request.options.out_of_division_play_once = True
+        request.options.num_weeks = 13
         url = "http://127.0.0.1:8080/generate-schedule"
         req_dict = json_format.MessageToDict(
             request, preserving_proto_field_name=True
@@ -175,6 +176,7 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div2 Team {i+1}", division_id=2))
         request.options.in_division_play_twice = True
         request.options.out_of_division_play_once = True
+        request.options.num_weeks = 13
         url = "http://127.0.0.1:8080/generate-schedule"
         req_dict = json_format.MessageToDict(
             request, preserving_proto_field_name=True
@@ -201,6 +203,7 @@ class TestServerIntegration(unittest.TestCase):
             request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
         request.options.in_division_play_twice = True
         request.options.out_of_division_play_once = True
+        request.options.num_weeks = 13
         url = "http://127.0.0.1:8080/generate-schedule"
         req_dict = json_format.MessageToDict(
             request, preserving_proto_field_name=True


### PR DESCRIPTION
## Summary
- add `num_weeks` field to `Options` proto
- include `num_weeks` in server logging and schedule generation
- regenerate protobufs
- update example scripts to send the new option
- update integration tests to include `num_weeks`

## Testing
- `nox -s lint`
- `nox -s build`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687fafb4977c832eab6f4c50542ce3be