### PR TITLE
Fix deploy logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,5 @@ jobs:
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --version ${{ env.version }} \
             --promote \
-            --verbosity debug \
+            --verbosity=debug \
             --quiet

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,10 @@ jobs:
         run: echo "version=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
 
       - name: Deploy to App Engine
-        uses: google-github-actions/deploy-appengine@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          deliverables: app.yaml
-          version: ${{ env.version }}
-          promote: true
-          flags: --verbosity=debug
+        run: |
+          gcloud app deploy app.yaml \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --version ${{ env.version }} \
+            --promote \
+            --verbosity debug \
+            --quiet


### PR DESCRIPTION
## Summary
- run `gcloud app deploy` directly so the logs show up

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687fc2aaa544832e8dca3a11d943f8fd