### PR TITLE
Fix npm version bump workflow permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/npm-version-bump-pr.yml
+++ b/.github/workflows/npm-version-bump-pr.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- allow workflows to create PRs during npm version bump

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_687fd5288ecc832ea2be4b5118d50df7