### PR TITLE
Use gunicorn for production server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ENV PYTHONPATH=/app
 
 EXPOSE 8080
 
-CMD ["python", "src/server.py"]
+CMD ["gunicorn", "src.server:app", "--bind", "0.0.0.0:8080"]

--- a/README.md
+++ b/README.md
@@ -26,13 +26,21 @@ This will create the generated `_pb2.py` files next to your source code. You can
 
 ## Running the Server
 
-To run the HTTP server, use the following command:
+For production-style runs the application is served by Gunicorn. Start it
+directly with:
+
+```bash
+gunicorn src.server:app -b 0.0.0.0:8080
+```
+
+The `serve()` helper in `src/server.py` still uses Flask's built-in
+development server for quick local testing and is invoked by:
 
 ```bash
 nox -s run
 ```
 
-The server listens on port `8080` and exposes health endpoints:
+Both methods listen on port `8080` and expose health endpoints:
 
 * `/liveness_check`
 * `/readiness_check`
@@ -95,6 +103,7 @@ docker build -t schedule-server .
 docker run -p 8080:8080 schedule-server
 ```
 
-The image compiles the protobuf definitions during build and starts the HTTP server on port `8080`.
-The `compile_protos.py` script is copied into the image so that any new `.proto` files will be included automatically.
+The image compiles the protobuf definitions during build and serves the app via
+Gunicorn on port `8080`. The `compile_protos.py` script is copied into the image
+so that any new `.proto` files will be included automatically.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,8 +12,10 @@ def run(session):
     session.install("-r", "requirements.txt")
     session.run("python", "compile_protos.py")
     session.run(
-        "python",
-        "src/server.py",
+        "gunicorn",
+        "src.server:app",
+        "--bind",
+        "0.0.0.0:8080",
         env={"PYTHONPATH": "."},
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ grpcio==1.73.1
 grpcio-tools==1.73.1
 grpcio-reflection==1.73.1
 Flask==3.0.3
+flask-cors==6.0.1
+gunicorn==22.0.0
 flake8==7.0.0
 black==24.4.2
-flask-cors==6.0.1

--- a/src/server.py
+++ b/src/server.py
@@ -102,6 +102,7 @@ def generate_schedule_http():
 
 
 def serve() -> None:
+    """Run the built-in development server."""
     logging.basicConfig(
         level=logging.INFO,
         format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",


### PR DESCRIPTION
## Summary
- add gunicorn to Python dependencies
- run app with gunicorn in Docker and nox
- document production and development server usage

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_689d11eb489c832e8b4b35e574561fb0