### PR TITLE
Validate weeks and team limits

### DIFF
--- a/src/schedule_generator.py
+++ b/src/schedule_generator.py
@@ -70,6 +70,10 @@ def generate_schedule(
         in_division_play_twice,
         out_of_division_play_once,
     )
+    if not 1 <= num_weeks <= 20:
+        raise ValueError("num_weeks must be between 1 and 20")
+    if num_teams > 32:
+        raise ValueError("num_teams must be 32 or less")
     weeks = range(num_weeks)
     teams = range(num_teams)
 

--- a/src/server.py
+++ b/src/server.py
@@ -49,8 +49,12 @@ def build_schedule_response(
     if num_teams == 0:
         logger.info("No teams provided in request")
         return response
+    if num_teams > 32:
+        raise ValueError("Number of teams must be 32 or less")
 
     num_weeks = req.options.num_weeks or 13
+    if not 1 <= num_weeks <= 20:
+        raise ValueError("num_weeks must be between 1 and 20")
 
     schedule_data = schedule_generator.generate_schedule(
         num_weeks,

--- a/tests/test_integration_server.py
+++ b/tests/test_integration_server.py
@@ -221,6 +221,56 @@ class TestServerIntegration(unittest.TestCase):
         body = json.loads(cm.exception.read().decode())
         self.assertIn("error", body)
 
+    def test_generate_schedule_invalid_num_weeks(self):
+        """Requests with invalid num_weeks should return an error."""
+        logging.info("Sending GenerateSchedule request with invalid num_weeks to server")
+        request = scheduler_pb2.ScheduleRequest()
+        for i in range(5):
+            request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
+            request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
+        request.options.in_division_play_twice = True
+        request.options.out_of_division_play_once = True
+        request.options.num_weeks = 21
+        url = "http://127.0.0.1:8080/generate-schedule"
+        req_dict = json_format.MessageToDict(
+            request, preserving_proto_field_name=True
+        )
+        data = json.dumps(req_dict).encode()
+        http_req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            urllib.request.urlopen(http_req)
+
+        self.assertEqual(cm.exception.code, 400)
+        body = json.loads(cm.exception.read().decode())
+        self.assertIn("error", body)
+
+    def test_generate_schedule_too_many_teams(self):
+        """Requests with more than 32 teams should return an error."""
+        logging.info("Sending GenerateSchedule request with too many teams to server")
+        request = scheduler_pb2.ScheduleRequest()
+        for i in range(17):
+            request.league.append(scheduler_pb2.Team(name=f"Div0 Team {i+1}", division_id=0))
+            request.league.append(scheduler_pb2.Team(name=f"Div1 Team {i+1}", division_id=1))
+        request.options.in_division_play_twice = True
+        request.options.out_of_division_play_once = True
+        request.options.num_weeks = 13
+        url = "http://127.0.0.1:8080/generate-schedule"
+        req_dict = json_format.MessageToDict(
+            request, preserving_proto_field_name=True
+        )
+        data = json.dumps(req_dict).encode()
+        http_req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}
+        )
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            urllib.request.urlopen(http_req)
+
+        self.assertEqual(cm.exception.code, 400)
+        body = json.loads(cm.exception.read().decode())
+        self.assertIn("error", body)
+
 
 if __name__ == "__main__":
     logging.basicConfig(

--- a/tests/test_schedule_generator.py
+++ b/tests/test_schedule_generator.py
@@ -147,6 +147,16 @@ class TestScheduleGenerator(unittest.TestCase):
         result = schedule_generator.generate_schedule(2, 2, True, True)
         self.assertEqual(result, "Error: Solver could not be created.")
 
+    def test_generate_schedule_invalid_num_weeks(self):
+        with self.assertRaises(ValueError):
+            schedule_generator.generate_schedule(0, 2)
+        with self.assertRaises(ValueError):
+            schedule_generator.generate_schedule(21, 2)
+
+    def test_generate_schedule_too_many_teams(self):
+        with self.assertRaises(ValueError):
+            schedule_generator.generate_schedule(13, 33)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enforce limits for weeks (1-20) and teams (max 32)
- add tests covering invalid weeks and excessive team counts

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68b111706e68832e9851796c56de532c